### PR TITLE
Add ADObject equality and hashing

### DIFF
--- a/ms_active_directory/core/ad_objects.py
+++ b/ms_active_directory/core/ad_objects.py
@@ -170,6 +170,14 @@ class ADObject:
     def __str__(self):
         return self.__repr__()
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return other.distinguished_name == self.distinguished_name and other.domain == self.domain
+
+    def __hash__(self):
+        return hash((self.distinguished_name, self.domain))
+
 
 class ADComputer(ADObject):
 


### PR DESCRIPTION
There are a few use cases where having an equality operation defined for ADObjects is required. In my logic, the only two members that need to be equal for two ADObjects to be considered equal would be distinguished_name and domain. For instance, if I have two ADGroup objects for the same group in the domain but one is queried with additional attributes, they should still be equal since they point to the same group. 