### PR TITLE
Minor tweaks and managed users

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ For more detailed documentation, please see the docs at:\
    for nested groups.
 9. Adding and removing users, computers, and groups to and from other groups
 10. Account management functionality for both users and computers, such as password changes/resets, enabling, disabling, and unlocking accounts
-12. Looking up information about the permissions set on a user, computer, group, or generic object
-13. Adding permissions to the security descriptor for a user, computer, group, or generic object
+11. Looking up information about the permissions set on a user, computer, group, or generic object
+12. Adding permissions to the security descriptor for a user, computer, group, or generic object
+13. Support for creating users and groups
 14. Support for updating attributes of users, computers, groups, and generic objects. Support exists for atomically appending 
     or overwriting values.
 15. Support for finding policies within a domain, and for finding the policies directly attached to any given object.

--- a/ms_active_directory/core/ad_objects.py
+++ b/ms_active_directory/core/ad_objects.py
@@ -173,10 +173,24 @@ class ADObject:
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
-        return other.distinguished_name == self.distinguished_name and other.domain == self.domain
+
+        same_dn = other.distinguished_name == self.distinguished_name
+        # only compare dns name for domain because things like site and ldap servers can vary, but that doesn't
+        # affect the objects within the domain
+        # this isn't perfect. but if you want perfect comparisons of objects, you should get their SIDs and compare
+        # those, as well as comparing their 'whenChanged' to ensure there's been no alteration across them.
+        # this provides basic equality without requiring permission to read those attributes
+        same_domain = other.domain.get_domain_dns_name() == self.domain.get_domain_dns_name()
+        return same_dn and same_domain
 
     def __hash__(self):
-        return hash((self.distinguished_name, self.domain))
+        # use the domain dns name and the object classes in the hash, so that if we delete something at this dn and
+        # make something different there it will make a different hash
+        # this isn't perfect. but if you want perfect representations of objects' state, you should get their SIDs and
+        # use those, as well as using their 'whenChanged', to build your own hash so that the hash changes whenever the
+        # object changes
+        # this provides basic hash functionality without requiring permission to read those attributes
+        return hash((self.distinguished_name, self.domain.get_domain_dns_name(), self.object_classes))
 
 
 class ADComputer(ADObject):

--- a/ms_active_directory/core/ad_session.py
+++ b/ms_active_directory/core/ad_session.py
@@ -55,7 +55,7 @@ import ms_active_directory.environment.security.security_config_constants as sec
 import ms_active_directory.environment.security.security_descriptor_utils as sd_utils
 
 from ms_active_directory import logging_utils
-from ms_active_directory.core.managed_ad_objects import ManagedADComputer
+from ms_active_directory.core.managed_ad_objects import ManagedADComputer, ManagedADUser
 from ms_active_directory.core.ad_objects import (
     ADComputer,
     ADGroup,
@@ -262,6 +262,104 @@ class ADSession:
         raise ObjectCreationException('An exception was encountered creating an object with distinguished name {} '
                                       'and object classes {}. LDAP result: {}'.format(object_dn, object_classes,
                                                                                       result))
+
+    def create_user(self, username: str, first_name: str, last_name: str, object_location: str, user_password: str,
+                    encryption_types: List[Union[str, security_constants.ADEncryptionType]] = None,
+                    common_name: str = None, supports_legacy_behavior: bool = False,
+                    **additional_user_attributes) -> ManagedADUser:
+        """ Use the session to create an unmanaged user in the domain and return a user object. This does not
+        configure any auth mechanisms for the user like a password or kerberos keys.
+        :param username: The login username for the user to create in the AD domain. This will be used to determine
+                         the sAMAccountName for the user.
+        :param first_name: The first name (given name) of the user to create in the AD domain. This will used for the
+                           givenName attribute for the user and as a part of the user display name.
+        :param last_name: The last name (surname) of the user to create in the AD domain. This will used for the
+                          sn (surname) attribute for the user and as a part of the user display name.
+        :param object_location: The distinguished name of the location within the domain where the user will be
+                                created. It may be a relative distinguished name (not including the domain component)
+                                or a full distinguished name.  If not specified, defaults to CN=Users which is
+                                standard for Active Directory.
+        :param user_password: The user's password.
+        :param encryption_types: A list of ADEncryptionType enums or strings representing kerberos encryption types
+                                 that the user can authenticate with. If not specified, defaults to AES256-SHA1.
+                                 These will also be used to generate user keys with their password.
+        :param common_name: The common name for the user. If unspecified, defaults to 'first_name last_name'.
+                            This is used as the common name in the user's distinguished name and the displayName
+                            attribute.
+        :param supports_legacy_behavior: Does the user being created support legacy behavior such as NTLM
+                                         authentication or UNC path addressing from older windows clients?
+                                         Defaults to False. Impacts the restrictions on user naming.
+        :param additional_user_attributes: Additional LDAP attributes to set on the user and their values.
+                                           This is used to support power users setting arbitrary attributes.
+                                           This also allows overriding of some values that are not explicit keyword
+                                           arguments in order to avoid over-complication, since most people won't
+                                           set them (e.g. userAccountControl).
+        :returns: a ManagedADUser object representing the user.
+        :raises: ObjectCreationException if we fail to create the user for a reason unrelated to what we can
+                 easily validate in advance (e.g. permission issue)
+        """
+        logger.debug('Request to create managed user in domain %s with the following attributes: username=%s, '
+                     'first_name=%s, last_name=%s, object_location=%s, encryption_types=%s, '
+                     'supports_legacy_behavior=%s, number of additional attributes specified: %s',
+                     self.domain_dns_name, first_name, last_name, object_location, encryption_types,
+                     supports_legacy_behavior, len(additional_user_attributes))
+
+        # validate our username
+        username = ldap_utils.validate_and_normalize_logon_name(username, supports_legacy_behavior)
+        if self.object_exists_in_domain_with_attribute(ldap_constants.AD_ATTRIBUTE_SAMACCOUNT_NAME, username):
+            raise ObjectCreationException('An object already exists with sAMAccountName {} so a user may not be '
+                                          'created with the username {}'.format(username, username))
+
+        # get or normalize our object location. the end format is as a relative distinguished name
+        object_location = self.validate_location_for_creation_or_movement_and_get_dn(
+            object_location,
+            ldap_constants.DEFAULT_USER_GROUP_LOCATION
+        )
+        # construct common name from first and last names if not specified
+        if not common_name:
+            common_name = first_name + ' ' + last_name
+        # now we can build our full object distinguished name
+        user_dn = ldap_utils.construct_object_distinguished_name(common_name, object_location, self.domain_dns_name)
+        if self.dn_exists_in_domain(user_dn):
+            raise ObjectCreationException('There exists an object in the domain with distinguished name {} and so a '
+                                          'user may not be created in the domain with name {} in location {}. '
+                                          'Please use a different name or location.'
+                                          .format(user_dn, common_name, object_location))
+
+        encoded_pw = security_utils.encode_password(user_password)
+
+        # normalize encryption type values and convert it to the encoded bitstring
+        if encryption_types is None:
+            encryption_types = [security_constants.ADEncryptionType.AES256_CTS_HMAC_SHA1_96]
+        else:
+            encryption_types = security_utils.normalize_encryption_type_list(encryption_types)
+        encoded_enc_type_value = security_utils.get_supported_encryption_types_value(encryption_types)
+
+        # construct userPrincipalName from username and domain
+        user_principal_name = username + '@' + self.domain_dns_name
+
+        user_attributes = {
+            ldap_constants.AD_ATTRIBUTE_DISPLAY_NAME: common_name,
+            ldap_constants.AD_ATTRIBUTE_SAMACCOUNT_NAME: username,
+            ldap_constants.AD_ATTRIBUTE_USER_PRINCIPAL_NAME: user_principal_name,
+            ldap_constants.AD_ATTRIBUTE_PASSWORD: encoded_pw,
+            ldap_constants.AD_ATTRIBUTE_ENCRYPTION_TYPES: encoded_enc_type_value,
+            ldap_constants.AD_ATTRIBUTE_GIVEN_NAME: first_name,
+            ldap_constants.AD_ATTRIBUTE_SURNAME: last_name,
+        }
+        loggable_attributes = copy.deepcopy(user_attributes)
+        del loggable_attributes[ldap_constants.AD_ATTRIBUTE_PASSWORD]
+        logger.info(
+            'Attempting to create user in domain %s with the following LDAP attributes: %s and %s additional '
+            'attributes', self.domain_dns_name, loggable_attributes, len(additional_user_attributes))
+
+        # add in our additional account attributes at the end so they can override anything we set here
+        user_attributes.update(additional_user_attributes)
+
+        self._create_object(user_dn, ldap_constants.OBJECT_CLASSES_FOR_USER, user_attributes,
+                            sanity_check_for_existence=False)  # we already checked for this
+        return ManagedADUser(username, self.domain, location=object_location, password=user_password,
+                             encryption_types=encryption_types, kvno=1, common_name=common_name)
 
     def create_unmanaged_user(self, username: str, first_name: str, last_name: str, object_location: str,
                               common_name: str = None, supports_legacy_behavior: bool = False,

--- a/ms_active_directory/core/managed_ad_objects.py
+++ b/ms_active_directory/core/managed_ad_objects.py
@@ -411,3 +411,189 @@ class ManagedADComputer(ManagedADObject):
         self.kvno += 1
         logger.debug('Updated kvno for computer %s from %s to %s', self.computer_name, self.kvno - 1, self.kvno)
         self.set_password_locally(password)
+
+
+class ManagedADUser(ManagedADObject):
+
+    def __init__(self, samaccount_name: str, domain: 'ADDomain', location: str = None,
+                 password: str = None, encryption_types: List[ADEncryptionType] = None, kvno: int = None,
+                 common_name: str = None):
+        super().__init__(samaccount_name, domain, location, password)
+        self.common_name = common_name if common_name else self.samaccount_name
+        self.name = self.common_name
+        self.encryption_types = []
+        encryption_types = encryption_types if encryption_types else []
+        for enc_type in encryption_types:
+            original = enc_type
+            if isinstance(enc_type, str):
+                enc_type = ENCRYPTION_TYPE_STR_TO_ENUM.get(enc_type.lower())
+            if not isinstance(enc_type, ADEncryptionType):
+                raise ValueError('All specified encryption types must be ADEncryptionType enums or must '
+                                 'be strings convertible to ADEncryptionType enums. {} is neither.'
+                                 .format(original))
+            self.encryption_types.append(enc_type)
+        # assume the account is a new account unless given a kvno
+        self.kvno = 1 if kvno is None else kvno
+
+        self.kerberos_keys = []
+        self.raw_kerberos_keys = []
+        if self.password:
+            logger.debug('Generating kerberos keys from password during instantiation of user with name %s',
+                         self.name)
+            for enc_type in self.encryption_types:
+                raw_key = ad_password_string_to_key(enc_type, self.samaccount_name,
+                                                    self.password, self.domain_dns_name, is_user=True)
+                self.raw_kerberos_keys.append(raw_key)
+                # generate our user kerberos key
+                user_gss_kerberos_key = GssKerberosKey(self.samaccount_name, self.realm, raw_key, self.kvno,
+                                                       gss_name_type=AD_DEFAULT_NAME_TYPE)
+                self.kerberos_keys.append(user_gss_kerberos_key)
+            logger.debug('Generated %s kerberos keys from password during instantiation of user with name %s',
+                         len(self.kerberos_keys), self.name)
+
+    def add_encryption_type_locally(self, encryption_type: ADEncryptionType):
+        """ Adds an encryption type to the user locally. This will generate new kerberos keys
+        for the user using the new encryption type.
+        This function does nothing if the encryption type is already on the user.
+        This function raises an exception if the user's password is not set, as the password is
+        needed to generate new kerberos keys.
+        :param encryption_type: The encryption type to add to the user.
+        """
+        if encryption_type in self.encryption_types:
+            logger.debug(
+                'No change resulted from adding encryption type %s to user %s locally as it was already present',
+                encryption_type, self.name)
+            return
+        if self.password is None:
+            raise InvalidComputerParameterException('Encryption types can only be added to a user locally if its '
+                                                    'password is known. Without the password, new kerberos keys cannot '
+                                                    'be generated.')
+        logger.debug('Adding encryption type %s to user %s locally',
+                     encryption_type, self.name)
+        self.encryption_types.append(encryption_type)
+        raw_krb_key = ad_password_string_to_key(encryption_type, self.samaccount_name,
+                                                self.password, self.domain_dns_name, is_user=True)
+        self.raw_kerberos_keys.append(raw_krb_key)
+        user_gss_kerberos_key = GssKerberosKey(self.samaccount_name, self.realm, raw_krb_key, self.kvno,
+                                               gss_name_type=AD_DEFAULT_NAME_TYPE)
+        self.kerberos_keys.append(user_gss_kerberos_key)
+
+    def get_full_keytab_file_bytes_for_user(self) -> bytes:
+        """ Get the raw bytes that would comprise a complete keytab file for this user. The
+        resultant bytes form a file that can be used to initiate GSS security contexts as the user
+        with the user's principal name being the sAMAccountName.
+        """
+        return write_gss_kerberos_key_list_to_raw_bytes(self.kerberos_keys)
+
+    def get_computer_distinguished_name(self) -> str:
+        """ Get the LDAP distinguished name for the user. This raises an exception if location is not
+        set for the user.
+        """
+        if self.location is None:
+            raise InvalidComputerParameterException('The location of the computer is unknown and so a distinguished '
+                                                    'name cannot be determined for it.')
+        return construct_object_distinguished_name(self.common_name, self.location, self.domain_dns_name)
+
+    def get_encryption_types(self) -> List[ADEncryptionType]:
+        return self.encryption_types
+
+    def get_name(self) -> str:
+        return self.name
+
+    def get_user_kerberos_keys(self) -> List[GssKerberosKey]:
+        return self.kerberos_keys
+
+    def get_user_principal_name(self) -> str:
+        """ Gets the user principal name for the computer, to be used in initiating GSS security contexts """
+        return '{sam}@{realm}'.format(sam=self.samaccount_name, realm=self.realm)
+
+    def set_encryption_types_locally(self, encryption_types: List[ADEncryptionType]):
+        """ Sets the encryption types of the user locally. This will generate new kerberos keys
+        for the user using the new encryption types.
+        This function raises an exception if the user's password is not set, as the password is
+        needed to generate new kerberos keys.
+        :param encryption_types: The list of AD encryption types to set on the user.
+        """
+        if self.password is None:
+            raise InvalidComputerParameterException('Encryption types can only be set on a computer locally if its '
+                                                    'password is known. Without the password, new kerberos keys cannot '
+                                                    'be generated.')
+
+        new_kerberos_keys = []
+        new_raw_kerberos_keys = []
+        logger.debug('Adding new encryption types %s to user %s locally',
+                     encryption_types, self.name)
+        for encryption_type in encryption_types:
+            raw_krb_key = ad_password_string_to_key(encryption_type, self.samaccount_name,
+                                                    self.password, self.domain_dns_name, is_user=True)
+            new_raw_kerberos_keys.append(raw_krb_key)
+            user_gss_kerberos_key = GssKerberosKey(self.samaccount_name, self.realm, raw_krb_key, self.kvno,
+                                                   gss_name_type=AD_DEFAULT_NAME_TYPE)
+            new_kerberos_keys.append(user_gss_kerberos_key)
+        self.encryption_types = encryption_types
+        self.kerberos_keys = new_kerberos_keys
+        self.raw_kerberos_keys = new_raw_kerberos_keys
+        logger.debug('Generated %s new kerberos keys for new encryption types %s set on user %s locally',
+                     len(new_kerberos_keys), encryption_types, self.name)
+
+    def set_password_locally(self, password: str):
+        """ Sets the password on the AD user locally. This will regenerate user kerberos keys for all of the
+        encryption types on the user.
+        This function is meant to be used when the password was not set locally or was incorrectly set.
+        This function WILL NOT update the key version number of the kerberos keys; if a user's
+        password is actually changed, then update_password_locally should be used as that will update
+        the key version number properly and ensure the resultant kerberos keys can be properly used
+        for initiating and accepting security contexts.
+        :param password: The string password to set for the computer.
+        """
+        self.password = password
+        self.kerberos_keys = []
+        self.raw_kerberos_keys = []
+        logger.debug('Generating new kerberos keys for user %s based on new password',
+                     self.name)
+        for enc_type in self.encryption_types:
+            raw_key = ad_password_string_to_key(enc_type, self.samaccount_name,
+                                                self.password, self.domain_dns_name, is_user=True)
+            self.raw_kerberos_keys.append(raw_key)
+            # generate our user kerberos key
+            user_gss_kerberos_key = GssKerberosKey(self.samaccount_name, self.realm, raw_key, self.kvno,
+                                                   gss_name_type=AD_DEFAULT_NAME_TYPE)
+            self.kerberos_keys.append(user_gss_kerberos_key)
+        logger.info('Generated %s new kerberos keys for user %s based on new password and forgot old keys',
+                    len(self.kerberos_keys), self.name)
+
+    def write_keytab_file_for_user(self, file_path: str, merge_with_existing_file: bool = True):
+        """ Write all of the keytabs for this user to a file, which are the keys used to authenticate
+        with servers when acting as a client.
+
+        :param file_path: The path to the file where the keytabs will be written. If it does not exist, it will be
+                          created.
+        :param merge_with_existing_file: If True, the users' keytabs will be added into the keytab file at
+                                         `file_path` if one exists. If False, the file at `file_path` will be
+                                         overwritten if it exists. If the file does not exist, this does nothing.
+                                         Defaults to True.
+        """
+        logger.debug('Writing user key file for %s to %s', self.name, file_path)
+        entries_to_write = self.kerberos_keys
+        if merge_with_existing_file:
+            logger.debug('Merging with existing keytab file')
+            current_entries = process_keytab_file_to_extract_entries(file_path, must_exist=False)
+            logger.debug('%s existing keytabs found in file %s for merge', len(current_entries), file_path)
+            entries_to_write += current_entries
+        data = write_gss_kerberos_key_list_to_raw_bytes(entries_to_write)
+        self._write_keytab_data(file_path, data)
+        logger.info('Successfully wrote user key file with %s keys for %s to %s',
+                    len(self.kerberos_keys), self.name, file_path)
+
+    def _write_keytab_data(self, file_path: str, data: bytes):
+        with open(file_path, 'wb') as fp:
+            fp.write(data)
+
+    def update_password_locally(self, password: str):
+        """ Update the password for the computer locally and generate new kerberos keys for the new
+        password.
+        :param password: The string password to set for the computer.
+        """
+        self.kvno += 1
+        logger.debug('Updated kvno for user %s from %s to %s', self.name, self.kvno - 1, self.kvno)
+        self.set_password_locally(password)

--- a/ms_active_directory/environment/kerberos/kerberos_constants.py
+++ b/ms_active_directory/environment/kerberos/kerberos_constants.py
@@ -65,8 +65,9 @@ PRINCIPAL_COMPONENT_DIVIDER = '/'
 # here begin constants used to generate raw kerberos keys
 AES_CIPHER_BLOCK_SIZE_BYTES = 16
 AES_ITERATIONS_FOR_AD = 4096
-
-SALT_FORMAT_FOR_AD = '{uppercase_realm}host{lowercase_computer_name}.{lowercase_domain}'
+# see docs at https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/2a32282e-dd48-4ad9-a542-609804b02cc9
+SALT_FORMAT_FOR_AD_COMPUTERS = '{uppercase_realm}host{lowercase_computer_name}.{lowercase_domain}'
+SALT_FORMAT_FOR_AD_USERS = '{uppercase_realm}{logon_name}'
 
 # AD uses a bitstring to encode supported encryption types, so the values for
 # encryption types in AD are not the same as the values for encryption types

--- a/ms_active_directory/environment/ldap/ldap_format_utils.py
+++ b/ms_active_directory/environment/ldap/ldap_format_utils.py
@@ -349,9 +349,11 @@ def strip_domain_from_object_location(location: str, domain_dns_name: str) -> st
     return location
 
 
-def validate_and_normalize_common_name(name: str, supports_legacy_behavior: bool) -> str:
-    """ Common names are sAMAccountNames without the $ at the end. So check for allowable characters and length limits
-    with the option to support legacy behavior.
+def validate_and_normalize_logon_name(name: str, supports_legacy_behavior: bool) -> str:
+    """ User logon names are sAMAccountNames, and computer logon names are sAMAccountNames without the $ at the end.
+    So check for allowable characters and length limits with the option to support legacy behavior.
+    Users and computers using older authentication protocols that support pre-windows 2000 behavior have different
+    restrictions on things like length.
     """
     limit = LEGACY_SAM_ACCOUNT_NAME_LENGTH_LIMIT if supports_legacy_behavior else SAM_ACCOUNT_NAME_LENGTH
     # peel off the ending $ if present


### PR DESCRIPTION
    Did some minor renaming, changes to docstrings, and changes to
    equality/hash logic.
    Streamlined location validation logic into its own function.
    Updated README to mention new functionality and updated docs.

    Added the ability to create users with a password and have kerberos
    keys generated for them simultaneously.
    The salt for AD users and AD computers is differently formed, with
    users being closer to the traditional MIT Kerberos salt, while
    computers are totally different. So updates were made there as well.
