### PR TITLE
Dev to main for 1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ For more detailed documentation, please see the docs at:\
    for nested groups.
 9. Adding and removing users, computers, and groups to and from other groups
 10. Account management functionality for both users and computers, such as password changes/resets, enabling, disabling, and unlocking accounts
-12. Looking up information about the permissions set on a user, computer, group, or generic object
-13. Adding permissions to the security descriptor for a user, computer, group, or generic object
+11. Looking up information about the permissions set on a user, computer, group, or generic object
+12. Adding permissions to the security descriptor for a user, computer, group, or generic object
+13. Support for creating users and groups
 14. Support for updating attributes of users, computers, groups, and generic objects. Support exists for atomically appending 
     or overwriting values.
 15. Support for finding policies within a domain, and for finding the policies directly attached to any given object.

--- a/docs/source/ad_domain.rst
+++ b/docs/source/ad_domain.rst
@@ -19,7 +19,8 @@ and such is done using an ``ADDomain`` object::
                  discover_kerberos_servers: bool = True,
                  dns_nameservers: List[str] = None,
                  source_ip: str = None,
-                 netbios_name: str = None)
+                 netbios_name: str = None,
+                 auto_configure_kerberos_client: bool = False)
             Initializes an interface for defining an AD domain and interacting with it.
 
             :param domain: The DNS name of the Active Directory domain that this object represents.
@@ -69,6 +70,8 @@ and such is done using an ``ADDomain`` object::
                                  This can be set by users, but isn't needed. It's primarily here to avoid
                                  extra lookups when creating ADDomain objects from ADTrustedDomain objects, as
                                  the netbios name is already known.
+            :param auto_configure_kerberos_client: If true, automatically configure the local system to enable kerberos
+                                                   communication with the domain.
 
 
 As can be seen, creating a domain is fairly flexible. The only actual *required* parameter is the domain's dns name.

--- a/ms_active_directory/__init__.py
+++ b/ms_active_directory/__init__.py
@@ -62,6 +62,9 @@ from ms_active_directory.environment.kerberos.kerberos_raw_key_generator import 
     ad_password_string_to_key,
     password_string_to_key
 )
+from ms_active_directory.environment.kerberos.kerberos_client_configurer import (
+    update_system_kerberos_configuration_for_domains
+)
 
 from ms_active_directory.environment.ldap.ldap_constants import *
 

--- a/ms_active_directory/__init__.py
+++ b/ms_active_directory/__init__.py
@@ -24,7 +24,9 @@
 # SOFTWARE.
 
 from ms_active_directory.core.managed_ad_objects import (
-    ManagedADComputer
+    ManagedADComputer,
+    ManagedADObject,
+    ManagedADUser,
 )
 
 from ms_active_directory.core.ad_domain import (

--- a/ms_active_directory/core/ad_objects.py
+++ b/ms_active_directory/core/ad_objects.py
@@ -173,10 +173,24 @@ class ADObject:
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
-        return other.distinguished_name == self.distinguished_name and other.domain == self.domain
+
+        same_dn = other.distinguished_name == self.distinguished_name
+        # only compare dns name for domain because things like site and ldap servers can vary, but that doesn't
+        # affect the objects within the domain
+        # this isn't perfect. but if you want perfect comparisons of objects, you should get their SIDs and compare
+        # those, as well as comparing their 'whenChanged' to ensure there's been no alteration across them.
+        # this provides basic equality without requiring permission to read those attributes
+        same_domain = other.domain.get_domain_dns_name() == self.domain.get_domain_dns_name()
+        return same_dn and same_domain
 
     def __hash__(self):
-        return hash((self.distinguished_name, self.domain))
+        # use the domain dns name and the object classes in the hash, so that if we delete something at this dn and
+        # make something different there it will make a different hash
+        # this isn't perfect. but if you want perfect representations of objects' state, you should get their SIDs and
+        # use those, as well as using their 'whenChanged', to build your own hash so that the hash changes whenever the
+        # object changes
+        # this provides basic hash functionality without requiring permission to read those attributes
+        return hash((self.distinguished_name, self.domain.get_domain_dns_name(), self.object_classes))
 
 
 class ADComputer(ADObject):

--- a/ms_active_directory/core/ad_objects.py
+++ b/ms_active_directory/core/ad_objects.py
@@ -170,6 +170,14 @@ class ADObject:
     def __str__(self):
         return self.__repr__()
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return other.distinguished_name == self.distinguished_name and other.domain == self.domain
+
+    def __hash__(self):
+        return hash((self.distinguished_name, self.domain))
+
 
 class ADComputer(ADObject):
 

--- a/ms_active_directory/core/ad_session.py
+++ b/ms_active_directory/core/ad_session.py
@@ -55,7 +55,7 @@ import ms_active_directory.environment.security.security_config_constants as sec
 import ms_active_directory.environment.security.security_descriptor_utils as sd_utils
 
 from ms_active_directory import logging_utils
-from ms_active_directory.core.managed_ad_objects import ManagedADComputer
+from ms_active_directory.core.managed_ad_objects import ManagedADComputer, ManagedADUser
 from ms_active_directory.core.ad_objects import (
     ADComputer,
     ADGroup,
@@ -263,6 +263,104 @@ class ADSession:
                                       'and object classes {}. LDAP result: {}'.format(object_dn, object_classes,
                                                                                       result))
 
+    def create_user(self, username: str, first_name: str, last_name: str, object_location: str, user_password: str,
+                    encryption_types: List[Union[str, security_constants.ADEncryptionType]] = None,
+                    common_name: str = None, supports_legacy_behavior: bool = False,
+                    **additional_user_attributes) -> ManagedADUser:
+        """ Use the session to create an unmanaged user in the domain and return a user object. This does not
+        configure any auth mechanisms for the user like a password or kerberos keys.
+        :param username: The login username for the user to create in the AD domain. This will be used to determine
+                         the sAMAccountName for the user.
+        :param first_name: The first name (given name) of the user to create in the AD domain. This will used for the
+                           givenName attribute for the user and as a part of the user display name.
+        :param last_name: The last name (surname) of the user to create in the AD domain. This will used for the
+                          sn (surname) attribute for the user and as a part of the user display name.
+        :param object_location: The distinguished name of the location within the domain where the user will be
+                                created. It may be a relative distinguished name (not including the domain component)
+                                or a full distinguished name.  If not specified, defaults to CN=Users which is
+                                standard for Active Directory.
+        :param user_password: The user's password.
+        :param encryption_types: A list of ADEncryptionType enums or strings representing kerberos encryption types
+                                 that the user can authenticate with. If not specified, defaults to AES256-SHA1.
+                                 These will also be used to generate user keys with their password.
+        :param common_name: The common name for the user. If unspecified, defaults to 'first_name last_name'.
+                            This is used as the common name in the user's distinguished name and the displayName
+                            attribute.
+        :param supports_legacy_behavior: Does the user being created support legacy behavior such as NTLM
+                                         authentication or UNC path addressing from older windows clients?
+                                         Defaults to False. Impacts the restrictions on user naming.
+        :param additional_user_attributes: Additional LDAP attributes to set on the user and their values.
+                                           This is used to support power users setting arbitrary attributes.
+                                           This also allows overriding of some values that are not explicit keyword
+                                           arguments in order to avoid over-complication, since most people won't
+                                           set them (e.g. userAccountControl).
+        :returns: a ManagedADUser object representing the user.
+        :raises: ObjectCreationException if we fail to create the user for a reason unrelated to what we can
+                 easily validate in advance (e.g. permission issue)
+        """
+        logger.debug('Request to create managed user in domain %s with the following attributes: username=%s, '
+                     'first_name=%s, last_name=%s, object_location=%s, encryption_types=%s, '
+                     'supports_legacy_behavior=%s, number of additional attributes specified: %s',
+                     self.domain_dns_name, first_name, last_name, object_location, encryption_types,
+                     supports_legacy_behavior, len(additional_user_attributes))
+
+        # validate our username
+        username = ldap_utils.validate_and_normalize_logon_name(username, supports_legacy_behavior)
+        if self.object_exists_in_domain_with_attribute(ldap_constants.AD_ATTRIBUTE_SAMACCOUNT_NAME, username):
+            raise ObjectCreationException('An object already exists with sAMAccountName {} so a user may not be '
+                                          'created with the username {}'.format(username, username))
+
+        # get or normalize our object location. the end format is as a relative distinguished name
+        object_location = self.validate_location_for_creation_or_movement_and_get_dn(
+            object_location,
+            ldap_constants.DEFAULT_USER_GROUP_LOCATION
+        )
+        # construct common name from first and last names if not specified
+        if not common_name:
+            common_name = first_name + ' ' + last_name
+        # now we can build our full object distinguished name
+        user_dn = ldap_utils.construct_object_distinguished_name(common_name, object_location, self.domain_dns_name)
+        if self.dn_exists_in_domain(user_dn):
+            raise ObjectCreationException('There exists an object in the domain with distinguished name {} and so a '
+                                          'user may not be created in the domain with name {} in location {}. '
+                                          'Please use a different name or location.'
+                                          .format(user_dn, common_name, object_location))
+
+        encoded_pw = security_utils.encode_password(user_password)
+
+        # normalize encryption type values and convert it to the encoded bitstring
+        if encryption_types is None:
+            encryption_types = [security_constants.ADEncryptionType.AES256_CTS_HMAC_SHA1_96]
+        else:
+            encryption_types = security_utils.normalize_encryption_type_list(encryption_types)
+        encoded_enc_type_value = security_utils.get_supported_encryption_types_value(encryption_types)
+
+        # construct userPrincipalName from username and domain
+        user_principal_name = username + '@' + self.domain_dns_name
+
+        user_attributes = {
+            ldap_constants.AD_ATTRIBUTE_DISPLAY_NAME: common_name,
+            ldap_constants.AD_ATTRIBUTE_SAMACCOUNT_NAME: username,
+            ldap_constants.AD_ATTRIBUTE_USER_PRINCIPAL_NAME: user_principal_name,
+            ldap_constants.AD_ATTRIBUTE_PASSWORD: encoded_pw,
+            ldap_constants.AD_ATTRIBUTE_ENCRYPTION_TYPES: encoded_enc_type_value,
+            ldap_constants.AD_ATTRIBUTE_GIVEN_NAME: first_name,
+            ldap_constants.AD_ATTRIBUTE_SURNAME: last_name,
+        }
+        loggable_attributes = copy.deepcopy(user_attributes)
+        del loggable_attributes[ldap_constants.AD_ATTRIBUTE_PASSWORD]
+        logger.info(
+            'Attempting to create user in domain %s with the following LDAP attributes: %s and %s additional '
+            'attributes', self.domain_dns_name, loggable_attributes, len(additional_user_attributes))
+
+        # add in our additional account attributes at the end so they can override anything we set here
+        user_attributes.update(additional_user_attributes)
+
+        self._create_object(user_dn, ldap_constants.OBJECT_CLASSES_FOR_USER, user_attributes,
+                            sanity_check_for_existence=False)  # we already checked for this
+        return ManagedADUser(username, self.domain, location=object_location, password=user_password,
+                             encryption_types=encryption_types, kvno=1, common_name=common_name)
+
     def create_unmanaged_user(self, username: str, first_name: str, last_name: str, object_location: str,
                               common_name: str = None, supports_legacy_behavior: bool = False,
                               **additional_user_attributes) -> ADUser:
@@ -299,36 +397,16 @@ class ADSession:
                      object_location, supports_legacy_behavior, len(additional_user_attributes))
 
         # validate our username
-        username = ldap_utils.validate_and_normalize_common_name(username, supports_legacy_behavior)
+        username = ldap_utils.validate_and_normalize_logon_name(username, supports_legacy_behavior)
         if self.object_exists_in_domain_with_attribute(ldap_constants.AD_ATTRIBUTE_SAMACCOUNT_NAME, username):
             raise ObjectCreationException('An object already exists with sAMAccountName {} so a user may not be '
                                           'created with the username {}'.format(username, username))
 
         # get or normalize our object location. the end format is as a relative distinguished name
-        # TODO: create helper function that normalizes an object location
-        if object_location is None:
-            object_location = ldap_constants.DEFAULT_USER_GROUP_LOCATION
-        else:
-            object_location = ldap_utils.normalize_object_location_in_domain(object_location, self.domain_dns_name)
-            # make sure our location exists
-            if ldap_utils.is_dn(object_location):
-                location_obj = self.find_object_by_distinguished_name(object_location)
-            else:
-                location_obj = self.find_object_by_canonical_name(object_location)
-            if location_obj is None:
-                raise ObjectCreationException('The user location {} cannot be found in the domain.'
-                                              .format(object_location))
-            # make sure our location is a container
-            is_container_or_ou = (location_obj.is_of_object_class(ldap_constants.ORGANIZATIONAL_UNIT_OBJECT_CLASS)
-                                  or location_obj.is_of_object_class(ldap_constants.CONTAINER_OBJECT_CLASS))
-            if not is_container_or_ou:
-                raise ObjectCreationException('The specified user location {} exists, but is not a container or an '
-                                              'organizational unit, and so a group cannot be created there.'
-                                              .format(location_obj.distinguished_name))
-            # make sure that going forward we have an LDAP-style relative distinguished name for our
-            # location
-            object_location = ldap_utils.normalize_object_location_in_domain(location_obj.distinguished_name,
-                                                                             self.domain_dns_name)
+        object_location = self.validate_location_for_creation_or_movement_and_get_dn(
+            object_location,
+            ldap_constants.DEFAULT_USER_GROUP_LOCATION
+        )
         # construct common name from first and last names if not specified
         if not common_name:
             common_name = first_name + ' ' + last_name
@@ -387,30 +465,10 @@ class ADSession:
                                           'created with the name {}'.format(group_name, group_name))
 
         # get or normalize our group location. the end format is as a relative distinguished name
-        # TODO: create helper function that normalizes an object location
-        if object_location is None:
-            object_location = ldap_constants.DEFAULT_USER_GROUP_LOCATION
-        else:
-            object_location = ldap_utils.normalize_object_location_in_domain(object_location, self.domain_dns_name)
-            # make sure our location exists
-            if ldap_utils.is_dn(object_location):
-                location_obj = self.find_object_by_distinguished_name(object_location)
-            else:
-                location_obj = self.find_object_by_canonical_name(object_location)
-            if location_obj is None:
-                raise ObjectCreationException('The group location {} cannot be found in the domain.'
-                                              .format(object_location))
-            # make sure our location is a container
-            is_container_or_ou = (location_obj.is_of_object_class(ldap_constants.ORGANIZATIONAL_UNIT_OBJECT_CLASS)
-                                  or location_obj.is_of_object_class(ldap_constants.CONTAINER_OBJECT_CLASS))
-            if not is_container_or_ou:
-                raise ObjectCreationException('The specified group location {} exists, but is not a container or an '
-                                              'organizational unit, and so a group cannot be created there.'
-                                              .format(location_obj.distinguished_name))
-            # make sure that going forward we have an LDAP-style relative distinguished name for our
-            # location
-            object_location = ldap_utils.normalize_object_location_in_domain(location_obj.distinguished_name,
-                                                                             self.domain_dns_name)
+        object_location = self.validate_location_for_creation_or_movement_and_get_dn(
+            object_location,
+            ldap_constants.DEFAULT_USER_GROUP_LOCATION
+        )
 
         # now we can build our full object distinguished name
         group_dn = ldap_utils.construct_object_distinguished_name(group_name, object_location,
@@ -488,7 +546,7 @@ class ADSession:
                      computer_location, encryption_types, hostnames, services, supports_legacy_behavior,
                      len(additional_account_attributes))
         # validate our computer name and then determine our sAMAccountName
-        computer_name = ldap_utils.validate_and_normalize_common_name(computer_name, supports_legacy_behavior)
+        computer_name = ldap_utils.validate_and_normalize_logon_name(computer_name, supports_legacy_behavior)
         samaccount_name = computer_name + '$'
 
         if self.object_exists_in_domain_with_attribute(ldap_constants.AD_ATTRIBUTE_SAMACCOUNT_NAME, samaccount_name):
@@ -496,30 +554,10 @@ class ADSession:
                                       'created with the name {}'.format(samaccount_name, computer_name))
 
         # get or normalize our computer location. the end format is as a relative distinguished name
-        if computer_location is None:
-            computer_location = ldap_constants.DEFAULT_COMPUTER_LOCATION
-        else:
-            computer_location = ldap_utils.normalize_object_location_in_domain(computer_location,
-                                                                               self.domain_dns_name)
-            # make sure our location exists
-            if ldap_utils.is_dn(computer_location):
-                location_obj = self.find_object_by_distinguished_name(computer_location)
-            else:
-                location_obj = self.find_object_by_canonical_name(computer_location)
-            if location_obj is None:
-                raise DomainJoinException('The computer location {} cannot be found in the domain.'
-                                          .format(computer_location))
-            # make sure our location is a container
-            is_container_or_ou = (location_obj.is_of_object_class(ldap_constants.ORGANIZATIONAL_UNIT_OBJECT_CLASS)
-                                  or location_obj.is_of_object_class(ldap_constants.CONTAINER_OBJECT_CLASS))
-            if not is_container_or_ou:
-                raise DomainJoinException('The specified computer location {} exists, but is not a container or an '
-                                          'organizational unit, and so a computer cannot be created there.'
-                                          .format(location_obj.distinguished_name))
-            # make sure that going forward we have an LDAP-style relative distinguished name for our
-            # location
-            computer_location = ldap_utils.normalize_object_location_in_domain(location_obj.distinguished_name,
-                                                                               self.domain_dns_name)
+        computer_location = self.validate_location_for_creation_or_movement_and_get_dn(
+            computer_location,
+            ldap_constants.DEFAULT_COMPUTER_LOCATION
+        )
 
         # now we can build our full object distinguished name
         computer_dn = ldap_utils.construct_object_distinguished_name(computer_name, computer_location,
@@ -3545,6 +3583,44 @@ class ADSession:
         return self.ldap_connection.extend.standard.who_am_i()
 
     # internal validation utils
+
+    def validate_location_for_creation_or_movement_and_get_dn(self, object_location: Optional[str],
+                                                              default_location: str) -> str:
+        """ A function for validating that a location actually exists within the domain and is of a type (OU or
+        container) such that other objects can be placed there. This is used heavily internally, but does not
+        start with an underscore in case people find it useful externally too.
+
+        :param object_location: The location to be validated. If null, the default location is returned. The format
+                                may either be a distinguished name (relative or absolute) or a canonical name
+                                (relative or absolute).
+        :param default_location: A string relative dn that is the default location to return if object_location is null
+        :returns: A string relative distinguished name representing the location.
+        :raises: An InvalidLdapParameterException is the location does not exist or is not able to contain objects
+        """
+        if object_location is None:
+            object_location = default_location
+        else:
+            object_location = ldap_utils.normalize_object_location_in_domain(object_location, self.domain_dns_name)
+            # make sure our location exists
+            if ldap_utils.is_dn(object_location):
+                location_obj = self.find_object_by_distinguished_name(object_location)
+            else:
+                location_obj = self.find_object_by_canonical_name(object_location)
+            if location_obj is None:
+                raise ObjectCreationException('The user location {} cannot be found in the domain.'
+                                              .format(object_location))
+            # make sure our location is a container
+            is_container_or_ou = (location_obj.is_of_object_class(ldap_constants.ORGANIZATIONAL_UNIT_OBJECT_CLASS)
+                                  or location_obj.is_of_object_class(ldap_constants.CONTAINER_OBJECT_CLASS))
+            if not is_container_or_ou:
+                raise InvalidLdapParameterException('The specified location {} exists, but is not a container or an '
+                                                    'organizational unit, and so other objects cannot be created there.'
+                                                    .format(location_obj.distinguished_name))
+            # make sure that going forward we have an LDAP-style relative distinguished name for our
+            # location
+            object_location = ldap_utils.normalize_object_location_in_domain(location_obj.distinguished_name,
+                                                                             self.domain_dns_name)
+        return object_location
 
     def _validate_group_and_get_group_obj(self, group: Union[str, ADGroup], skip_validation=False) -> ADGroup:
         if isinstance(group, str):

--- a/ms_active_directory/core/ad_session.py
+++ b/ms_active_directory/core/ad_session.py
@@ -263,6 +263,104 @@ class ADSession:
                                       'and object classes {}. LDAP result: {}'.format(object_dn, object_classes,
                                                                                       result))
 
+    def create_unmanaged_user(self, username: str, first_name: str, last_name: str, object_location: str,
+                              common_name: str = None, supports_legacy_behavior: bool = False,
+                              **additional_user_attributes) -> ADUser:
+        """ Use the session to create an unmanaged user in the domain and return a user object. This does not
+        configure any auth mechanisms for the user like a password or kerberos keys.
+        :param username: The login username for the user to create in the AD domain. This will be used to determine
+                         the sAMAccountName for the user.
+        :param first_name: The first name (given name) of the user to create in the AD domain. This will used for the
+                           givenName attribute for the user and as a part of the user display name.
+        :param last_name: The last name (surname) of the user to create in the AD domain. This will used for the
+                          sn (surname) attribute for the user and as a part of the user display name.
+        :param object_location: The distinguished name of the location within the domain where the user will be
+                                created. It may be a relative distinguished name (not including the domain component)
+                                or a full distinguished name.  If not specified, defaults to CN=Users which is
+                                standard for Active Directory.
+        :param common_name: The common name for the user. If unspecified, defaults to 'first_name last_name'.
+                            This is used as the common name in the user's distinguished name and the displayName
+                            attribute.
+        :param supports_legacy_behavior: Does the user being created support legacy behavior such as NTLM
+                                         authentication or UNC path addressing from older windows clients?
+                                         Defaults to False. Impacts the restrictions on user naming.
+        :param additional_user_attributes: Additional LDAP attributes to set on the user and their values.
+                                           This is used to support power users setting arbitrary attributes.
+                                           This also allows overriding of some values that are not explicit keyword
+                                           arguments in order to avoid over-complication, since most people won't
+                                           set them (e.g. userAccountControl).
+        :returns: an ADUser object representing the user.
+        :raises: ObjectCreationException if we fail to create the user for a reason unrelated to what we can
+                 easily validate in advance (e.g. permission issue)
+        """
+        logger.debug('Request to create user in domain %s with the following attributes: username=%s, '
+                     'first_name=%s, last_name=%s, object_location=%s, supports_legacy_behavior=%s, number of '
+                     'additional attributes specified: %s', self.domain_dns_name, first_name, last_name,
+                     object_location, supports_legacy_behavior, len(additional_user_attributes))
+
+        # validate our username
+        username = ldap_utils.validate_and_normalize_common_name(username, supports_legacy_behavior)
+        if self.object_exists_in_domain_with_attribute(ldap_constants.AD_ATTRIBUTE_SAMACCOUNT_NAME, username):
+            raise ObjectCreationException('An object already exists with sAMAccountName {} so a user may not be '
+                                          'created with the username {}'.format(username, username))
+
+        # get or normalize our object location. the end format is as a relative distinguished name
+        # TODO: create helper function that normalizes an object location
+        if object_location is None:
+            object_location = ldap_constants.DEFAULT_USER_GROUP_LOCATION
+        else:
+            object_location = ldap_utils.normalize_object_location_in_domain(object_location, self.domain_dns_name)
+            # make sure our location exists
+            if ldap_utils.is_dn(object_location):
+                location_obj = self.find_object_by_distinguished_name(object_location)
+            else:
+                location_obj = self.find_object_by_canonical_name(object_location)
+            if location_obj is None:
+                raise ObjectCreationException('The user location {} cannot be found in the domain.'
+                                              .format(object_location))
+            # make sure our location is a container
+            is_container_or_ou = (location_obj.is_of_object_class(ldap_constants.ORGANIZATIONAL_UNIT_OBJECT_CLASS)
+                                  or location_obj.is_of_object_class(ldap_constants.CONTAINER_OBJECT_CLASS))
+            if not is_container_or_ou:
+                raise ObjectCreationException('The specified user location {} exists, but is not a container or an '
+                                              'organizational unit, and so a group cannot be created there.'
+                                              .format(location_obj.distinguished_name))
+            # make sure that going forward we have an LDAP-style relative distinguished name for our
+            # location
+            object_location = ldap_utils.normalize_object_location_in_domain(location_obj.distinguished_name,
+                                                                             self.domain_dns_name)
+        # construct common name from first and last names if not specified
+        if not common_name:
+            common_name = first_name + ' ' + last_name
+        # now we can build our full object distinguished name
+        user_dn = ldap_utils.construct_object_distinguished_name(common_name, object_location, self.domain_dns_name)
+        if self.dn_exists_in_domain(user_dn):
+            raise ObjectCreationException('There exists an object in the domain with distinguished name {} and so a '
+                                          'user may not be created in the domain with name {} in location {}. '
+                                          'Please use a different name or location.'
+                                          .format(user_dn, common_name, object_location))
+
+        # construct userPrincipalName from username and domain
+        user_principal_name = username + '@' + self.domain_dns_name
+
+        user_attributes = {
+            ldap_constants.AD_ATTRIBUTE_DISPLAY_NAME: common_name,
+            ldap_constants.AD_ATTRIBUTE_SAMACCOUNT_NAME: username,
+            ldap_constants.AD_ATTRIBUTE_USER_PRINCIPAL_NAME: user_principal_name,
+            ldap_constants.AD_ATTRIBUTE_GIVEN_NAME: first_name,
+            ldap_constants.AD_ATTRIBUTE_SURNAME: last_name,
+        }
+        logger.info(
+            'Attempting to create user in domain %s with the following LDAP attributes: %s and %s additional '
+            'attributes', self.domain_dns_name, user_attributes, len(additional_user_attributes))
+
+        # add in our additional account attributes at the end so they can override anything we set here
+        user_attributes.update(additional_user_attributes)
+
+        self._create_object(user_dn, ldap_constants.OBJECT_CLASSES_FOR_USER, user_attributes,
+                            sanity_check_for_existence=False)  # we already checked for this
+        return ADUser(user_dn, user_attributes, self.domain)
+
     def create_group(self, group_name: str, object_location: str, **additional_group_attributes) -> ADGroup:
         """ Use the session to create a group in the domain and return a group object.
         :param group_name: The common name of the group to create in the AD domain. This will be used to determine
@@ -307,7 +405,8 @@ class ADSession:
                                   or location_obj.is_of_object_class(ldap_constants.CONTAINER_OBJECT_CLASS))
             if not is_container_or_ou:
                 raise ObjectCreationException('The specified group location {} exists, but is not a container or an '
-                                              'organizational unit, and so a group cannot be created there.')
+                                              'organizational unit, and so a group cannot be created there.'
+                                              .format(location_obj.distinguished_name))
             # make sure that going forward we have an LDAP-style relative distinguished name for our
             # location
             object_location = ldap_utils.normalize_object_location_in_domain(location_obj.distinguished_name,
@@ -389,7 +488,7 @@ class ADSession:
                      computer_location, encryption_types, hostnames, services, supports_legacy_behavior,
                      len(additional_account_attributes))
         # validate our computer name and then determine our sAMAccountName
-        computer_name = ldap_utils.validate_and_normalize_computer_name(computer_name, supports_legacy_behavior)
+        computer_name = ldap_utils.validate_and_normalize_common_name(computer_name, supports_legacy_behavior)
         samaccount_name = computer_name + '$'
 
         if self.object_exists_in_domain_with_attribute(ldap_constants.AD_ATTRIBUTE_SAMACCOUNT_NAME, samaccount_name):
@@ -415,7 +514,8 @@ class ADSession:
                                   or location_obj.is_of_object_class(ldap_constants.CONTAINER_OBJECT_CLASS))
             if not is_container_or_ou:
                 raise DomainJoinException('The specified computer location {} exists, but is not a container or an '
-                                          'organizational unit, and so a computer cannot be created there.')
+                                          'organizational unit, and so a computer cannot be created there.'
+                                          .format(location_obj.distinguished_name))
             # make sure that going forward we have an LDAP-style relative distinguished name for our
             # location
             computer_location = ldap_utils.normalize_object_location_in_domain(location_obj.distinguished_name,

--- a/ms_active_directory/core/managed_ad_objects.py
+++ b/ms_active_directory/core/managed_ad_objects.py
@@ -411,3 +411,189 @@ class ManagedADComputer(ManagedADObject):
         self.kvno += 1
         logger.debug('Updated kvno for computer %s from %s to %s', self.computer_name, self.kvno - 1, self.kvno)
         self.set_password_locally(password)
+
+
+class ManagedADUser(ManagedADObject):
+
+    def __init__(self, samaccount_name: str, domain: 'ADDomain', location: str = None,
+                 password: str = None, encryption_types: List[ADEncryptionType] = None, kvno: int = None,
+                 common_name: str = None):
+        super().__init__(samaccount_name, domain, location, password)
+        self.common_name = common_name if common_name else self.samaccount_name
+        self.name = self.common_name
+        self.encryption_types = []
+        encryption_types = encryption_types if encryption_types else []
+        for enc_type in encryption_types:
+            original = enc_type
+            if isinstance(enc_type, str):
+                enc_type = ENCRYPTION_TYPE_STR_TO_ENUM.get(enc_type.lower())
+            if not isinstance(enc_type, ADEncryptionType):
+                raise ValueError('All specified encryption types must be ADEncryptionType enums or must '
+                                 'be strings convertible to ADEncryptionType enums. {} is neither.'
+                                 .format(original))
+            self.encryption_types.append(enc_type)
+        # assume the account is a new account unless given a kvno
+        self.kvno = 1 if kvno is None else kvno
+
+        self.kerberos_keys = []
+        self.raw_kerberos_keys = []
+        if self.password:
+            logger.debug('Generating kerberos keys from password during instantiation of user with name %s',
+                         self.name)
+            for enc_type in self.encryption_types:
+                raw_key = ad_password_string_to_key(enc_type, self.samaccount_name,
+                                                    self.password, self.domain_dns_name, is_user=True)
+                self.raw_kerberos_keys.append(raw_key)
+                # generate our user kerberos key
+                user_gss_kerberos_key = GssKerberosKey(self.samaccount_name, self.realm, raw_key, self.kvno,
+                                                       gss_name_type=AD_DEFAULT_NAME_TYPE)
+                self.kerberos_keys.append(user_gss_kerberos_key)
+            logger.debug('Generated %s kerberos keys from password during instantiation of user with name %s',
+                         len(self.kerberos_keys), self.name)
+
+    def add_encryption_type_locally(self, encryption_type: ADEncryptionType):
+        """ Adds an encryption type to the user locally. This will generate new kerberos keys
+        for the user using the new encryption type.
+        This function does nothing if the encryption type is already on the user.
+        This function raises an exception if the user's password is not set, as the password is
+        needed to generate new kerberos keys.
+        :param encryption_type: The encryption type to add to the user.
+        """
+        if encryption_type in self.encryption_types:
+            logger.debug(
+                'No change resulted from adding encryption type %s to user %s locally as it was already present',
+                encryption_type, self.name)
+            return
+        if self.password is None:
+            raise InvalidComputerParameterException('Encryption types can only be added to a user locally if its '
+                                                    'password is known. Without the password, new kerberos keys cannot '
+                                                    'be generated.')
+        logger.debug('Adding encryption type %s to user %s locally',
+                     encryption_type, self.name)
+        self.encryption_types.append(encryption_type)
+        raw_krb_key = ad_password_string_to_key(encryption_type, self.samaccount_name,
+                                                self.password, self.domain_dns_name, is_user=True)
+        self.raw_kerberos_keys.append(raw_krb_key)
+        user_gss_kerberos_key = GssKerberosKey(self.samaccount_name, self.realm, raw_krb_key, self.kvno,
+                                               gss_name_type=AD_DEFAULT_NAME_TYPE)
+        self.kerberos_keys.append(user_gss_kerberos_key)
+
+    def get_full_keytab_file_bytes_for_user(self) -> bytes:
+        """ Get the raw bytes that would comprise a complete keytab file for this user. The
+        resultant bytes form a file that can be used to initiate GSS security contexts as the user
+        with the user's principal name being the sAMAccountName.
+        """
+        return write_gss_kerberos_key_list_to_raw_bytes(self.kerberos_keys)
+
+    def get_computer_distinguished_name(self) -> str:
+        """ Get the LDAP distinguished name for the user. This raises an exception if location is not
+        set for the user.
+        """
+        if self.location is None:
+            raise InvalidComputerParameterException('The location of the computer is unknown and so a distinguished '
+                                                    'name cannot be determined for it.')
+        return construct_object_distinguished_name(self.common_name, self.location, self.domain_dns_name)
+
+    def get_encryption_types(self) -> List[ADEncryptionType]:
+        return self.encryption_types
+
+    def get_name(self) -> str:
+        return self.name
+
+    def get_user_kerberos_keys(self) -> List[GssKerberosKey]:
+        return self.kerberos_keys
+
+    def get_user_principal_name(self) -> str:
+        """ Gets the user principal name for the computer, to be used in initiating GSS security contexts """
+        return '{sam}@{realm}'.format(sam=self.samaccount_name, realm=self.realm)
+
+    def set_encryption_types_locally(self, encryption_types: List[ADEncryptionType]):
+        """ Sets the encryption types of the user locally. This will generate new kerberos keys
+        for the user using the new encryption types.
+        This function raises an exception if the user's password is not set, as the password is
+        needed to generate new kerberos keys.
+        :param encryption_types: The list of AD encryption types to set on the user.
+        """
+        if self.password is None:
+            raise InvalidComputerParameterException('Encryption types can only be set on a computer locally if its '
+                                                    'password is known. Without the password, new kerberos keys cannot '
+                                                    'be generated.')
+
+        new_kerberos_keys = []
+        new_raw_kerberos_keys = []
+        logger.debug('Adding new encryption types %s to user %s locally',
+                     encryption_types, self.name)
+        for encryption_type in encryption_types:
+            raw_krb_key = ad_password_string_to_key(encryption_type, self.samaccount_name,
+                                                    self.password, self.domain_dns_name, is_user=True)
+            new_raw_kerberos_keys.append(raw_krb_key)
+            user_gss_kerberos_key = GssKerberosKey(self.samaccount_name, self.realm, raw_krb_key, self.kvno,
+                                                   gss_name_type=AD_DEFAULT_NAME_TYPE)
+            new_kerberos_keys.append(user_gss_kerberos_key)
+        self.encryption_types = encryption_types
+        self.kerberos_keys = new_kerberos_keys
+        self.raw_kerberos_keys = new_raw_kerberos_keys
+        logger.debug('Generated %s new kerberos keys for new encryption types %s set on user %s locally',
+                     len(new_kerberos_keys), encryption_types, self.name)
+
+    def set_password_locally(self, password: str):
+        """ Sets the password on the AD user locally. This will regenerate user kerberos keys for all of the
+        encryption types on the user.
+        This function is meant to be used when the password was not set locally or was incorrectly set.
+        This function WILL NOT update the key version number of the kerberos keys; if a user's
+        password is actually changed, then update_password_locally should be used as that will update
+        the key version number properly and ensure the resultant kerberos keys can be properly used
+        for initiating and accepting security contexts.
+        :param password: The string password to set for the computer.
+        """
+        self.password = password
+        self.kerberos_keys = []
+        self.raw_kerberos_keys = []
+        logger.debug('Generating new kerberos keys for user %s based on new password',
+                     self.name)
+        for enc_type in self.encryption_types:
+            raw_key = ad_password_string_to_key(enc_type, self.samaccount_name,
+                                                self.password, self.domain_dns_name, is_user=True)
+            self.raw_kerberos_keys.append(raw_key)
+            # generate our user kerberos key
+            user_gss_kerberos_key = GssKerberosKey(self.samaccount_name, self.realm, raw_key, self.kvno,
+                                                   gss_name_type=AD_DEFAULT_NAME_TYPE)
+            self.kerberos_keys.append(user_gss_kerberos_key)
+        logger.info('Generated %s new kerberos keys for user %s based on new password and forgot old keys',
+                    len(self.kerberos_keys), self.name)
+
+    def write_keytab_file_for_user(self, file_path: str, merge_with_existing_file: bool = True):
+        """ Write all of the keytabs for this user to a file, which are the keys used to authenticate
+        with servers when acting as a client.
+
+        :param file_path: The path to the file where the keytabs will be written. If it does not exist, it will be
+                          created.
+        :param merge_with_existing_file: If True, the users' keytabs will be added into the keytab file at
+                                         `file_path` if one exists. If False, the file at `file_path` will be
+                                         overwritten if it exists. If the file does not exist, this does nothing.
+                                         Defaults to True.
+        """
+        logger.debug('Writing user key file for %s to %s', self.name, file_path)
+        entries_to_write = self.kerberos_keys
+        if merge_with_existing_file:
+            logger.debug('Merging with existing keytab file')
+            current_entries = process_keytab_file_to_extract_entries(file_path, must_exist=False)
+            logger.debug('%s existing keytabs found in file %s for merge', len(current_entries), file_path)
+            entries_to_write += current_entries
+        data = write_gss_kerberos_key_list_to_raw_bytes(entries_to_write)
+        self._write_keytab_data(file_path, data)
+        logger.info('Successfully wrote user key file with %s keys for %s to %s',
+                    len(self.kerberos_keys), self.name, file_path)
+
+    def _write_keytab_data(self, file_path: str, data: bytes):
+        with open(file_path, 'wb') as fp:
+            fp.write(data)
+
+    def update_password_locally(self, password: str):
+        """ Update the password for the computer locally and generate new kerberos keys for the new
+        password.
+        :param password: The string password to set for the computer.
+        """
+        self.kvno += 1
+        logger.debug('Updated kvno for user %s from %s to %s', self.name, self.kvno - 1, self.kvno)
+        self.set_password_locally(password)

--- a/ms_active_directory/environment/kerberos/kerberos_client_configurer.py
+++ b/ms_active_directory/environment/kerberos/kerberos_client_configurer.py
@@ -1,0 +1,195 @@
+import os
+
+from typing import List, Optional, Tuple, TYPE_CHECKING
+
+from ms_active_directory.environment.kerberos.kerberos_constants import (
+    DEFAULT_REALM_FORMAT,
+    DOMAIN_REALM_MAP_FORMAT,
+    KRB5_CONF_DEFAULTS_TAG,
+    KRB5_CONF_DOMAIN_REALMS_TAG,
+    KRB5_CONF_REALMS_TAG,
+    POSIX_KRB5_CONF_LOCATION,
+    REALM_ENTRY_FORMAT,
+    REALM_ENTRY_COMPONENT_FORMAT,
+    WINDOWS_KRB5_CONF_LOCATION_NEW,
+    WINDOWS_KRB5_CONF_LOCATION_OLD,
+)
+from ms_active_directory.exceptions import SystemConfigurationUpdateException
+from ms_active_directory.logging_utils import get_logger
+
+if TYPE_CHECKING:
+    from ms_active_directory.core.ad_domain import ADDomain
+
+logger = get_logger()
+
+
+def update_system_kerberos_configuration_for_domains(ad_domains: List['ADDomain'],
+                                                     default_domain: 'ADDomain' = None,
+                                                     merge_with_existing_file: bool = True,
+                                                     krb5_location: str = None):
+    """ Update the system's kerberos configuration files for one or more AD domains in order to enable kerberos
+    authentication.
+
+    :param ad_domains: A list of ADDomain objects representing the domains.
+    :param default_domain: Optional. If specified, this domain will be configured as the default domain.
+    :param merge_with_existing_file: If False, overwrite the kerberos configuration file instead of merging the domain's
+                                     realm entries into the existing file. Defaults to True.
+    :param krb5_location: The file path to the kerberos configuration to update. If not specified, defaults to
+                          `/windows/krb5.ini` and `/winnt/krb5.ini` on windows systems and `/etc/krb5.conf` on others.
+    :raises: SystemConfigurationUpdateException if we fail to update the configuration files.
+    """
+    realm_entries = []
+    realms = []
+    domain_realm_map_entries = []
+    default_realm_entry = None
+    for domain in ad_domains:
+        realm = domain.get_domain_dns_name().upper()
+        lower_mapped_domain = realm.lower()
+        realm_components = [REALM_ENTRY_COMPONENT_FORMAT.format(server_type='kdc', address=addr)
+                            for addr in domain.get_kerberos_uris()]
+        realm_entry = REALM_ENTRY_FORMAT % (realm, '\n'.join(realm_components))
+        mapping_entry = DOMAIN_REALM_MAP_FORMAT.format(domain=lower_mapped_domain,
+                                                       realm=realm)
+        realms.append(realm)
+        realm_entries.append(realm_entry)
+        domain_realm_map_entries.append(mapping_entry)
+
+    if default_domain:
+        default_realm_entry = DEFAULT_REALM_FORMAT.format(realm=default_domain.get_domain_dns_name().upper())
+
+    # if the user specified the krb5 location, keep track of that. otherwise, guess based on our architecture
+    user_specified_output_location = False
+    if not krb5_location:
+        if os.name == 'nt':
+            # prefer the new location over the old one
+            krb5_locations = [WINDOWS_KRB5_CONF_LOCATION_NEW, WINDOWS_KRB5_CONF_LOCATION_OLD]
+        else:
+            krb5_locations = [POSIX_KRB5_CONF_LOCATION]
+    else:
+        krb5_locations = [krb5_location]
+        user_specified_output_location = True
+
+    # get our file contents
+    if not merge_with_existing_file:
+        krb5_contents = _build_krb5_conf_file(realm_entries, domain_realm_map_entries, default_realm_entry)
+    else:
+        read_location, current_krb5_lines = _read_existing_krb5_conf_file_lines(krb5_locations)
+        # if we found an existing krb5 config file, only update that location.
+        # if there was no existing file, then we'll write to all of the locations where the OS could look
+        if read_location is not None:
+            krb5_locations = [read_location]
+        # if we're setting the default realm, then drop the default realm from the current config
+        if default_realm_entry:
+            current_krb5_lines = [line for line in current_krb5_lines
+                                  if not line.strip().startswith('default_ream')]
+        krb5_contents = _combine_realms_into_current_krb5_file(current_krb5_lines, realms, realm_entries,
+                                                               domain_realm_map_entries, default_realm_entry)
+
+    # if the caller set the output location, we need to succeed in updating it or we'll raise an error.
+    # but if we're guessing at where to write, we might fail to write to one location because it doesn't exist
+    # as a directory (e.g. the new windows location on an old machine), so don't raise an exception unless all writes
+    # fail
+    any_locations_updated = False
+    for location in krb5_locations:
+        try:
+            with open(location, 'w') as krb5_fp:
+                krb5_fp.write(krb5_contents)
+                any_locations_updated = True
+            logger.info('Successfully wrote krb5 configuration to %s', location)
+        except Exception as ex:
+            logger.warning('Failed to update location %s with krb5 configuration. Exception %s', location, ex)
+            if user_specified_output_location:
+                raise SystemConfigurationUpdateException('Failed to update krb5 configuration file at {}'
+                                                         .format(location))
+    if not any_locations_updated:
+        raise SystemConfigurationUpdateException('Failed to update any krb5 configuration files after attempting to '
+                                                 'write to the following locations {}'
+                                                 .format(', '.join(krb5_locations)))
+
+
+def _build_krb5_conf_file(realm_entries: List[str], domain_realm_map_entries: List[str],
+                          default_realm_entry: str = None) -> str:
+    """ Create a krb5.conf file given the default realm (if any) and the entries for the realms and their domain
+    mappingsg
+    """
+    prefix = ''
+    if default_realm_entry:
+        prefix = KRB5_CONF_DEFAULTS_TAG + '\n' + default_realm_entry
+
+    realms = KRB5_CONF_REALMS_TAG + '\n' + '\n'.join(realm_entries)
+    domain_mappings = KRB5_CONF_DOMAIN_REALMS_TAG + '\n' + '\n'.join(domain_realm_map_entries)
+    return '\n'.join([prefix, realms, domain_mappings])
+
+
+def _read_existing_krb5_conf_file_lines(locations: List[str]) -> Tuple[Optional[str], List[str]]:
+    """ Read in existing krb5 configuration file lines and return them """
+    for loc in locations:
+        if os.path.isfile(loc):
+            with open(loc) as fp:
+                krb5_lines = fp.readlines()
+                # be careful of empty files
+                if krb5_lines:
+                    return loc, krb5_lines
+    return None, []
+
+
+def _combine_realms_into_current_krb5_file(current_krb5_lines: List[str], realms: List[str], realm_entries: List[str],
+                                           domain_realm_map_entries: List[str],
+                                           default_realm_entry: str = None) -> str:
+    """ Merge realm entries and domain->realm mappings into an existing krb5 configuration file's contents.
+    If the realms we have entries for are already existing in the configuration file, they're removed and replaced.
+    """
+    final_lines = []
+    realm_inserts = '\n'.join(realm_entries)
+    realms_inserted = False
+    domain_mapping_inserts = '\n'.join(domain_realm_map_entries)
+    domain_mappings_inserted = False
+    default_realm_inserted = True if default_realm_entry is None else False
+    currently_skipping_realm = None
+    for line in current_krb5_lines:
+        # firstly, if we're currently skipping a realm, skip this line and end the skipping if the line is the closing
+        # tag for the reaqulm
+        if currently_skipping_realm and line.strip() != '}':
+            print('Skipping line {line} of existing configuration for {realm} because we are overwriting it.'
+                        .format(line=line, realm=currently_skipping_realm))
+            continue
+        if currently_skipping_realm and line.strip() == '}':
+            currently_skipping_realm = None
+            print('Final line of configuration for {realm} seen. Done skipping {realm}'
+                        .format(realm=currently_skipping_realm))
+            continue
+
+        # if we're not actively skipping a realm's configuration, check if we should start
+        line_pieces = [piece.strip() for piece in line.split('=')]
+        if line_pieces[0] in realms and line_pieces[1] == '{':
+            currently_skipping_realm = line_pieces[0]
+            print('Starting to skip realm {realm} in existing configuration because we are overwriting it.'
+                        .format(realm=currently_skipping_realm))
+            continue
+
+        final_lines.append(line)
+        # if we've reached the krb5 defaults, and have a default realm entry, insert it
+        if line.strip() == KRB5_CONF_DEFAULTS_TAG and default_realm_entry:
+            final_lines.append(default_realm_entry)
+            default_realm_inserted = True
+        # if we've reached the realm definitions, insert our realms
+        if line.strip() == KRB5_CONF_REALMS_TAG:
+            final_lines.append(realm_inserts)
+            realms_inserted = True
+        # if we've reached the domain mapping definitions, insert our domains
+        if line.strip() == KRB5_CONF_DOMAIN_REALMS_TAG:
+            final_lines.append(domain_mapping_inserts)
+            domain_mappings_inserted = True
+
+    # if we didn't insert something, it means that the existing file didn't define it, so we add new sections as needed
+    if not default_realm_inserted:
+        final_lines.append(KRB5_CONF_DEFAULTS_TAG)
+        final_lines.append(default_realm_entry)
+    if not realms_inserted:
+        final_lines.append(KRB5_CONF_REALMS_TAG)
+        final_lines.append(realm_inserts)
+    if not domain_mappings_inserted:
+        final_lines.append(KRB5_CONF_DOMAIN_REALMS_TAG)
+        final_lines.append(domain_mapping_inserts)
+
+    return '\n'.join(final_lines) + '\n'

--- a/ms_active_directory/environment/kerberos/kerberos_constants.py
+++ b/ms_active_directory/environment/kerberos/kerberos_constants.py
@@ -128,3 +128,28 @@ DEFAULT_UNKNOWN_NAME_TYPE = 0
 AD_DEFAULT_NAME_TYPE = 1
 
 DEFAULT_KRB5_KEYTAB_FILE_LOCATION = '/etc/krb5.keytab'
+# some posix-based operating systems have other kerberos configs (e.g. macOS uses a plist, some
+# linux versions use /etc/krb5/krb5.conf) but all of them support /etc/krb5.conf for compatibility
+POSIX_KRB5_CONF_LOCATION = '/etc/krb5.conf'
+# windows puts the krb5 config in an ini file, but its location has changed across versions.
+# for backwards compatibility, windows will always look in the old location even if the new
+# one exists, so we update all of them
+WINDOWS_KRB5_CONF_LOCATION_NEW = '/windows/krb5.ini'
+WINDOWS_KRB5_CONF_LOCATION_OLD = '/winnt/krb5.ini'
+
+# config file tags
+KRB5_CONF_DEFAULTS_TAG = '[libdefaults]'
+KRB5_CONF_REALMS_TAG = '[realms]'
+KRB5_CONF_DOMAIN_REALMS_TAG = '[domain_realm]'
+
+# config file format elements
+DEFAULT_REALM_FORMAT = '    default_realm = {realm}'
+# needs to use %s formatting due to brackets in the file
+REALM_ENTRY_FORMAT = """    %s = {
+        %s
+    }
+"""
+REALM_ENTRY_COMPONENT_FORMAT = """        {server_type} = {address}"""
+DOMAIN_REALM_MAP_FORMAT = """    {domain} = {realm}
+    .{domain} = {realm}
+"""

--- a/ms_active_directory/environment/kerberos/kerberos_constants.py
+++ b/ms_active_directory/environment/kerberos/kerberos_constants.py
@@ -65,8 +65,9 @@ PRINCIPAL_COMPONENT_DIVIDER = '/'
 # here begin constants used to generate raw kerberos keys
 AES_CIPHER_BLOCK_SIZE_BYTES = 16
 AES_ITERATIONS_FOR_AD = 4096
-
-SALT_FORMAT_FOR_AD = '{uppercase_realm}host{lowercase_computer_name}.{lowercase_domain}'
+# see docs at https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/2a32282e-dd48-4ad9-a542-609804b02cc9
+SALT_FORMAT_FOR_AD_COMPUTERS = '{uppercase_realm}host{lowercase_computer_name}.{lowercase_domain}'
+SALT_FORMAT_FOR_AD_USERS = '{uppercase_realm}{logon_name}'
 
 # AD uses a bitstring to encode supported encryption types, so the values for
 # encryption types in AD are not the same as the values for encryption types

--- a/ms_active_directory/environment/ldap/ldap_constants.py
+++ b/ms_active_directory/environment/ldap/ldap_constants.py
@@ -35,9 +35,13 @@ POSIX_GROUP_OBJECT_CLASS = 'posixGroup'
 POSIX_USER_OBJECT_CLASS = 'posixAccount'
 USER_OBJECT_CLASS = 'user'
 TOP_OBJECT_CLASS = 'top'
+PERSON_OBJECT_CLASS = 'person'
+ORGANIZATIONAL_PERSON_OBJECT_CLASS = 'organizationalPerson'
 # computers also have the user object class because they can act as users to operate
 # within the domain, be a part of groups, etc.
 OBJECT_CLASSES_FOR_COMPUTER = [COMPUTER_OBJECT_CLASS, USER_OBJECT_CLASS, TOP_OBJECT_CLASS]
+OBJECT_CLASSES_FOR_USER = [TOP_OBJECT_CLASS, PERSON_OBJECT_CLASS, ORGANIZATIONAL_PERSON_OBJECT_CLASS, USER_OBJECT_CLASS]
+OBJECT_CLASSES_FOR_GROUP = [TOP_OBJECT_CLASS, GROUP_OBJECT_CLASS]
 
 # computers have an account control that determines things like whether they're trusted
 # for
@@ -65,6 +69,10 @@ AD_ATTRIBUTE_NETBIOS_NAME = 'nETBIOSName'
 AD_ATTRIBUTE_USER_ACCOUNT_CONTROL = 'userAccountControl'
 AD_ATTRIBUTE_SERVICE_PRINCIPAL_NAMES = 'servicePrincipalName'
 AD_ATTRIBUTE_PASSWORD = 'unicodePwd'
+AD_ATTRIBUTE_USER_PRINCIPAL_NAME = 'userPrincipalName'
+AD_ATTRIBUTE_GIVEN_NAME = 'givenName'  # user's given name (first name)
+AD_ATTRIBUTE_SURNAME = 'sn'  # user's surname (last name)
+AD_ATTRIBUTE_PRIMARY_GROUP_ID = 'primaryGroupID'
 # memberOf is a virtual attribute on users and groups, listing the DNs of groups that the record
 # belongs to. it's less efficient to query because it's constructed on-demand in a lot of scenarios,
 # and so we don't query for it by default, but use it if a user does query for it
@@ -77,6 +85,7 @@ AD_ATTRIBUTE_UID_NUMBER = 'uidNumber'  # posix user uid (uid is user name for ld
 AD_ATTRIBUTE_GID_NUMBER = 'gidNumber'  # posix group gid, or primary gid for user
 AD_ATTRIBUTE_UNIX_HOME_DIR = 'unixHomeDirectory'  # homedir for a posix user
 AD_ATTRIBUTE_UNIX_LOGIN_SHELL = 'loginShell'  # the login shell a user uses, e.g. /bin/bash, /bin/zsh
+AD_ATTRIBUTE_GECOS = 'gecos'  # the unix attribute containing the user's full name
 
 # keys for attributes that are relatively computer-specific
 AD_ATTRIBUTE_ENCRYPTION_TYPES = 'msDS-SupportedEncryptionTypes'
@@ -119,6 +128,7 @@ LEGACY_SAM_ACCOUNT_NAME_LENGTH_LIMIT = 16
 # related constants for domain-scope properties like dns servers and CAs
 DEFAULT_COMPUTER_SERVICES = ['HOST']
 DEFAULT_COMPUTER_LOCATION = 'CN=Computers'
+DEFAULT_USER_GROUP_LOCATION = 'CN=Users'
 DNS_SERVICE_FILTER = 'DNS/*'
 DOMAIN_WIDE_CONFIGURATIONS_CONTAINER = 'CN=Configuration'
 DOMAIN_CONTROLLER_SCHEMA_VERSION_SEARCH_CONTAINER = 'CN=schema,' + DOMAIN_WIDE_CONFIGURATIONS_CONTAINER

--- a/ms_active_directory/environment/ldap/ldap_format_utils.py
+++ b/ms_active_directory/environment/ldap/ldap_format_utils.py
@@ -349,9 +349,9 @@ def strip_domain_from_object_location(location: str, domain_dns_name: str) -> st
     return location
 
 
-def validate_and_normalize_computer_name(name: str, supports_legacy_behavior: bool) -> str:
-    """ Computer common names are sAMAccountNames without the $ at the end. So check for allowable
-    characters and length limits.
+def validate_and_normalize_common_name(name: str, supports_legacy_behavior: bool) -> str:
+    """ Common names are sAMAccountNames without the $ at the end. So check for allowable characters and length limits
+    with the option to support legacy behavior.
     """
     limit = LEGACY_SAM_ACCOUNT_NAME_LENGTH_LIMIT if supports_legacy_behavior else SAM_ACCOUNT_NAME_LENGTH
     # peel off the ending $ if present
@@ -359,10 +359,10 @@ def validate_and_normalize_computer_name(name: str, supports_legacy_behavior: bo
         name = name[:-1]
     if len(name) > limit:
         insert = 'support' if supports_legacy_behavior else 'do not support'
-        raise InvalidDomainParameterException('Computer name length must be fewer than {} characters for computers '
+        raise InvalidDomainParameterException('Common name length must be fewer than {} characters for accounts '
                                               'that {} legacy behavior.'.format(limit, insert))
     for character in AD_USERNAME_RESTRICTED_CHARS:
         if character in name:
-            raise InvalidDomainParameterException('AD computer names may not contain any of the following characters: '
+            raise InvalidDomainParameterException('Common names may not contain any of the following characters: '
                                                   '{}'.format(', '.join(AD_USERNAME_RESTRICTED_CHARS)))
     return name

--- a/ms_active_directory/environment/ldap/ldap_format_utils.py
+++ b/ms_active_directory/environment/ldap/ldap_format_utils.py
@@ -113,6 +113,18 @@ def construct_object_distinguished_name(object_name: str, object_location: str, 
     return ','.join([common_part, object_location, domain_part])
 
 
+def construct_ou_distinguished_name(ou_name: str, domain: str, object_location: str = '') -> str:
+    """
+    Constructs the distinguished name of an organizational unit given the ou name, join location, and domain.
+    """
+    ou_part = 'OU=' + ou_name
+    domain_part = construct_ldap_base_dn_from_domain(domain)
+    parts = [ou_part, domain_part]
+    if object_location:
+        parts.insert(1, object_location)
+    return ','.join(parts)
+
+
 def construct_domain_from_ldap_base_dn(domain: str) -> str:
     """
     Given a base DN, constructs the DNS name of the AD domain.

--- a/ms_active_directory/environment/ldap/ldap_format_utils.py
+++ b/ms_active_directory/environment/ldap/ldap_format_utils.py
@@ -349,9 +349,11 @@ def strip_domain_from_object_location(location: str, domain_dns_name: str) -> st
     return location
 
 
-def validate_and_normalize_common_name(name: str, supports_legacy_behavior: bool) -> str:
-    """ Common names are sAMAccountNames without the $ at the end. So check for allowable characters and length limits
-    with the option to support legacy behavior.
+def validate_and_normalize_logon_name(name: str, supports_legacy_behavior: bool) -> str:
+    """ User logon names are sAMAccountNames, and computer logon names are sAMAccountNames without the $ at the end.
+    So check for allowable characters and length limits with the option to support legacy behavior.
+    Users and computers using older authentication protocols that support pre-windows 2000 behavior have different
+    restrictions on things like length.
     """
     limit = LEGACY_SAM_ACCOUNT_NAME_LENGTH_LIMIT if supports_legacy_behavior else SAM_ACCOUNT_NAME_LENGTH
     # peel off the ending $ if present

--- a/ms_active_directory/exceptions.py
+++ b/ms_active_directory/exceptions.py
@@ -159,6 +159,12 @@ class SessionTransferException(MsActiveDirectoryException):
         super().__init__(exception_str)
 
 
+class SystemConfigurationUpdateException(MsActiveDirectoryException):
+    """ An exception raised if we fail to update local system configurations as requested """
+    def __init__(self, exception_str):
+        super().__init__(exception_str)
+
+
 class TrustedDomainConversionException(MsActiveDirectoryException):
     """ An exception raised when trying to convert a trusted domain that has a non-AD type
     to an ADDomain

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-version = '1.10.3'
+version = '1.11.0'
 author = 'Azaria Zornberg'
 email = 'a.zornberg96@gmail.com'
 license_str = 'MIT License'


### PR DESCRIPTION
New functionality in 1.11.0 includes:

1. Ability to locally configure a windows, macOS, or linux device's kerberos client when creating an `ADDomain` object, or independently using one or more `ADDomain` objects
2. Ability to create groups (thanks @TrinityDevelopers )
3. Ability to create unmanaged users (thanks @TrinityDevelopers )
4. Ability to create managed users, which (just like managed computers) will automatically generate kerberos keys for the users to authenticate with, and support a variety of auxiliary functionality
