### PR TITLE
Proposed fix for ADObject.__hash__, optimize create_user, cleanup docstrings

### DIFF
--- a/ms_active_directory/core/ad_objects.py
+++ b/ms_active_directory/core/ad_objects.py
@@ -190,7 +190,7 @@ class ADObject:
         # use those, as well as using their 'whenChanged', to build your own hash so that the hash changes whenever the
         # object changes
         # this provides basic hash functionality without requiring permission to read those attributes
-        return hash((self.distinguished_name, self.domain.get_domain_dns_name(), self.object_classes))
+        return hash((self.distinguished_name, self.domain.get_domain_dns_name(), tuple(self.object_classes)))
 
 
 class ADComputer(ADObject):

--- a/ms_active_directory/core/ad_session.py
+++ b/ms_active_directory/core/ad_session.py
@@ -267,8 +267,8 @@ class ADSession:
                     encryption_types: List[Union[str, security_constants.ADEncryptionType]] = None,
                     common_name: str = None, supports_legacy_behavior: bool = False,
                     **additional_user_attributes) -> ManagedADUser:
-        """ Use the session to create an unmanaged user in the domain and return a user object. This does not
-        configure any auth mechanisms for the user like a password or kerberos keys.
+        """ Use the session to create a managed user in the domain and return an ManagedADUser object. This creates
+        a user with a password and generates kerberos keys for them.
         :param username: The login username for the user to create in the AD domain. This will be used to determine
                          the sAMAccountName for the user.
         :param first_name: The first name (given name) of the user to create in the AD domain. This will used for the
@@ -304,28 +304,6 @@ class ADSession:
                      self.domain_dns_name, first_name, last_name, object_location, encryption_types,
                      supports_legacy_behavior, len(additional_user_attributes))
 
-        # validate our username
-        username = ldap_utils.validate_and_normalize_logon_name(username, supports_legacy_behavior)
-        if self.object_exists_in_domain_with_attribute(ldap_constants.AD_ATTRIBUTE_SAMACCOUNT_NAME, username):
-            raise ObjectCreationException('An object already exists with sAMAccountName {} so a user may not be '
-                                          'created with the username {}'.format(username, username))
-
-        # get or normalize our object location. the end format is as a relative distinguished name
-        object_location = self.validate_location_for_creation_or_movement_and_get_dn(
-            object_location,
-            ldap_constants.DEFAULT_USER_GROUP_LOCATION
-        )
-        # construct common name from first and last names if not specified
-        if not common_name:
-            common_name = first_name + ' ' + last_name
-        # now we can build our full object distinguished name
-        user_dn = ldap_utils.construct_object_distinguished_name(common_name, object_location, self.domain_dns_name)
-        if self.dn_exists_in_domain(user_dn):
-            raise ObjectCreationException('There exists an object in the domain with distinguished name {} and so a '
-                                          'user may not be created in the domain with name {} in location {}. '
-                                          'Please use a different name or location.'
-                                          .format(user_dn, common_name, object_location))
-
         encoded_pw = security_utils.encode_password(user_password)
 
         # normalize encryption type values and convert it to the encoded bitstring
@@ -335,29 +313,15 @@ class ADSession:
             encryption_types = security_utils.normalize_encryption_type_list(encryption_types)
         encoded_enc_type_value = security_utils.get_supported_encryption_types_value(encryption_types)
 
-        # construct userPrincipalName from username and domain
-        user_principal_name = username + '@' + self.domain_dns_name
-
         user_attributes = {
-            ldap_constants.AD_ATTRIBUTE_DISPLAY_NAME: common_name,
-            ldap_constants.AD_ATTRIBUTE_SAMACCOUNT_NAME: username,
-            ldap_constants.AD_ATTRIBUTE_USER_PRINCIPAL_NAME: user_principal_name,
             ldap_constants.AD_ATTRIBUTE_PASSWORD: encoded_pw,
             ldap_constants.AD_ATTRIBUTE_ENCRYPTION_TYPES: encoded_enc_type_value,
-            ldap_constants.AD_ATTRIBUTE_GIVEN_NAME: first_name,
-            ldap_constants.AD_ATTRIBUTE_SURNAME: last_name,
         }
-        loggable_attributes = copy.deepcopy(user_attributes)
-        del loggable_attributes[ldap_constants.AD_ATTRIBUTE_PASSWORD]
-        logger.info(
-            'Attempting to create user in domain %s with the following LDAP attributes: %s and %s additional '
-            'attributes', self.domain_dns_name, loggable_attributes, len(additional_user_attributes))
-
         # add in our additional account attributes at the end so they can override anything we set here
         user_attributes.update(additional_user_attributes)
 
-        self._create_object(user_dn, ldap_constants.OBJECT_CLASSES_FOR_USER, user_attributes,
-                            sanity_check_for_existence=False)  # we already checked for this
+        self.create_unmanaged_user(username, first_name, last_name, object_location, common_name,
+                                   supports_legacy_behavior, **user_attributes)
         return ManagedADUser(username, self.domain, location=object_location, password=user_password,
                              encryption_types=encryption_types, kvno=1, common_name=common_name)
 

--- a/ms_active_directory/core/managed_ad_objects.py
+++ b/ms_active_directory/core/managed_ad_objects.py
@@ -485,12 +485,12 @@ class ManagedADUser(ManagedADObject):
         """
         return write_gss_kerberos_key_list_to_raw_bytes(self.kerberos_keys)
 
-    def get_computer_distinguished_name(self) -> str:
+    def get_user_distinguished_name(self) -> str:
         """ Get the LDAP distinguished name for the user. This raises an exception if location is not
         set for the user.
         """
         if self.location is None:
-            raise InvalidComputerParameterException('The location of the computer is unknown and so a distinguished '
+            raise InvalidComputerParameterException('The location of the user is unknown and so a distinguished '
                                                     'name cannot be determined for it.')
         return construct_object_distinguished_name(self.common_name, self.location, self.domain_dns_name)
 
@@ -515,7 +515,7 @@ class ManagedADUser(ManagedADObject):
         :param encryption_types: The list of AD encryption types to set on the user.
         """
         if self.password is None:
-            raise InvalidComputerParameterException('Encryption types can only be set on a computer locally if its '
+            raise InvalidComputerParameterException('Encryption types can only be set on a user locally if its '
                                                     'password is known. Without the password, new kerberos keys cannot '
                                                     'be generated.')
 
@@ -544,7 +544,7 @@ class ManagedADUser(ManagedADObject):
         password is actually changed, then update_password_locally should be used as that will update
         the key version number properly and ensure the resultant kerberos keys can be properly used
         for initiating and accepting security contexts.
-        :param password: The string password to set for the computer.
+        :param password: The string password to set for the user.
         """
         self.password = password
         self.kerberos_keys = []
@@ -590,9 +590,9 @@ class ManagedADUser(ManagedADObject):
             fp.write(data)
 
     def update_password_locally(self, password: str):
-        """ Update the password for the computer locally and generate new kerberos keys for the new
+        """ Update the password for the user locally and generate new kerberos keys for the new
         password.
-        :param password: The string password to set for the computer.
+        :param password: The string password to set for the user.
         """
         self.kvno += 1
         logger.debug('Updated kvno for user %s from %s to %s', self.name, self.kvno - 1, self.kvno)


### PR DESCRIPTION
Proposed fix for `ADObject.__hash__` by passing`self.object_classes` as a tuple. Fixes #29.
Proposed optimization of `create_user` by calling `self.create_unamanged_user` to prevent duplicate code.
Cleanup some docstrings and a few function names with references to computer instead of user.