### PR TITLE
Dev to master for 1.11.1

### DIFF
--- a/ms_active_directory/__init__.py
+++ b/ms_active_directory/__init__.py
@@ -24,7 +24,9 @@
 # SOFTWARE.
 
 from ms_active_directory.core.managed_ad_objects import (
-    ManagedADComputer
+    ManagedADComputer,
+    ManagedADObject,
+    ManagedADUser,
 )
 
 from ms_active_directory.core.ad_domain import (

--- a/ms_active_directory/core/managed_ad_objects.py
+++ b/ms_active_directory/core/managed_ad_objects.py
@@ -52,7 +52,7 @@ from ms_active_directory.environment.security.security_config_constants import (
     ADEncryptionType,
     ENCRYPTION_TYPE_STR_TO_ENUM,
 )
-from ms_active_directory.exceptions import InvalidComputerParameterException
+from ms_active_directory.exceptions import InvalidComputerParameterException, InvalidUserParameterException
 
 logger = logging_utils.get_logger()
 
@@ -465,9 +465,9 @@ class ManagedADUser(ManagedADObject):
                 encryption_type, self.name)
             return
         if self.password is None:
-            raise InvalidComputerParameterException('Encryption types can only be added to a user locally if its '
-                                                    'password is known. Without the password, new kerberos keys cannot '
-                                                    'be generated.')
+            raise InvalidUserParameterException('Encryption types can only be added to a user locally if its '
+                                                'password is known. Without the password, new kerberos keys cannot '
+                                                'be generated.')
         logger.debug('Adding encryption type %s to user %s locally',
                      encryption_type, self.name)
         self.encryption_types.append(encryption_type)
@@ -490,8 +490,8 @@ class ManagedADUser(ManagedADObject):
         set for the user.
         """
         if self.location is None:
-            raise InvalidComputerParameterException('The location of the user is unknown and so a distinguished '
-                                                    'name cannot be determined for it.')
+            raise InvalidUserParameterException('The location of the user is unknown and so a distinguished '
+                                                'name cannot be determined for it.')
         return construct_object_distinguished_name(self.common_name, self.location, self.domain_dns_name)
 
     def get_encryption_types(self) -> List[ADEncryptionType]:
@@ -515,9 +515,9 @@ class ManagedADUser(ManagedADObject):
         :param encryption_types: The list of AD encryption types to set on the user.
         """
         if self.password is None:
-            raise InvalidComputerParameterException('Encryption types can only be set on a user locally if its '
-                                                    'password is known. Without the password, new kerberos keys cannot '
-                                                    'be generated.')
+            raise InvalidUserParameterException('Encryption types can only be set on a user locally if its '
+                                                'password is known. Without the password, new kerberos keys cannot '
+                                                'be generated.')
 
         new_kerberos_keys = []
         new_raw_kerberos_keys = []

--- a/ms_active_directory/environment/ldap/ldap_constants.py
+++ b/ms_active_directory/environment/ldap/ldap_constants.py
@@ -45,6 +45,7 @@ OBJECT_CLASSES_FOR_GROUP = [TOP_OBJECT_CLASS, GROUP_OBJECT_CLASS]
 
 # computers have an account control that determines things like whether they're trusted
 # for
+NORMAL_USER = 512
 WORKSTATION_TRUST_ACCOUNT = 4096
 DONT_EXPIRE_PASSWORD = 65536
 ACCOUNT_DISABLED = 2

--- a/ms_active_directory/exceptions.py
+++ b/ms_active_directory/exceptions.py
@@ -91,6 +91,14 @@ class InvalidLdapParameterException(MsActiveDirectoryException):
         super().__init__(exception_str)
 
 
+class InvalidUserParameterException(MsActiveDirectoryException):
+    """ An exception raised when functions are called on a ManagedADUser object with invalid
+    parameters or that rely on unpopulated attributes.
+    """
+    def __init__(self, exception_str):
+        super().__init__(exception_str)
+
+
 class KeytabEncodingException(MsActiveDirectoryException):
     """ An exception raised when a keytab is read in from a file but the encoding is invalid """
     def __init__(self, exception_str):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-version = '1.11.0'
+version = '1.11.1'
 author = 'Azaria Zornberg'
 email = 'a.zornberg96@gmail.com'
 license_str = 'MIT License'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-version = '1.10.3'
+version = '1.11.0'
 author = 'Azaria Zornberg'
 email = 'a.zornberg96@gmail.com'
 license_str = 'MIT License'


### PR DESCRIPTION
Contains some small touch-ups for user creation and other issues.

    - Made location and password optional
    - Specified a user account control so that users wouldn't be disabled
      by default in some domains
    - Made unique error classes for managed users
    - fixed an issue with hash calculation in `ADObject`s (thanks @TrinityDevelopers )
    - cleaned up some docstrings and streamlined user creation code for managed and unmanaged users (thanks @TrinityDevelopers )