### PR TITLE
Start adding primary group support for users and computers

### DIFF
--- a/ms_active_directory/core/ad_objects.py
+++ b/ms_active_directory/core/ad_objects.py
@@ -139,7 +139,7 @@ class ADObject:
                 self.policy_enablement_state_map[policy_dn.lower()] = enablement_enum
 
     def get(self, attribute_name: str, unpack_one_item_lists=False):
-        """ Get an attribute about the group that isn't explicitly tracked as a member """
+        """ Get an attribute about the object that isn't explicitly tracked as a member """
         val = self.all_attributes.get(attribute_name)
         # there's a lot of 1-item lists from the ldap3 library
         if isinstance(val, list) and len(val) == 1 and unpack_one_item_lists:

--- a/ms_active_directory/core/ad_session.py
+++ b/ms_active_directory/core/ad_session.py
@@ -1676,8 +1676,9 @@ class ADSession:
                                 Defaults to False. This can be used to make this function more performant when
                                 the caller knows all the distinguished names being specified are valid, as it
                                 performs far fewer queries.
-        :param include_primary: If true, includes the entities' primary groups in the returned groups. This adds a
-                                significant performance cost so only enable this if needed.
+        :param include_primary: If true, includes the entities' primary groups as the first entry in each entity's
+                                returned group list. This adds an additional performance cost so only enable this
+                                if needed.
         :returns: A dictionary mapping input entities to lists of ADGroup object representing their parent groups.
         :raises: a DuplicateNameException if an entity name is specified and more than one entry exists with the name.
         :raises: InvalidLdapParameterException if any non-string non-ADObject types are found in entities, or if any
@@ -1829,8 +1830,8 @@ class ADSession:
                                 Defaults to False. This can be used to make this function more performant when
                                 the caller knows all the distinguished names being specified are valid, as it
                                 performs far fewer queries.
-        :param include_primary: If true, includes the user's primary group in the returned groups. This adds a
-                                significant performance cost so only enable this if needed.
+        :param include_primary: If true, includes the user's primary group as the first entry in the returned group
+                                list. This adds an additional performance cost so only enable this if needed.
         :returns: A list of ADGroup objects representing the groups that this user belongs to.
         :raises: a DuplicateNameException if a user name is specified and more than one entry exists with the name.
         :raises: a InvalidLdapParameterException if the user name is not a string or ADUser.
@@ -1856,8 +1857,9 @@ class ADSession:
                                 Defaults to False. This can be used to make this function more performant when
                                 the caller knows all the distinguished names being specified are valid, as it
                                 performs far fewer queries.
-        :param include_primary: If true, includes the users' primary groups in the returned groups. This adds a
-                                significant performance cost so only enable this if needed.
+        :param include_primary: If true, includes the users' primary groups as the first entry in each user's
+                                returned group list. This adds an additional performance cost so only enable this
+                                if needed.
         :returns: A dictionary mapping users to lists of ADGroup objects representing the groups that they belong to.
         :raises: a DuplicateNameException if a user name is specified and more than one entry exists with the name.
         :raises: a InvalidLdapParameterException if any users are not a string or ADUser.
@@ -1881,8 +1883,8 @@ class ADSession:
                                 Defaults to False. This can be used to make this function more performant when
                                 the caller knows all the distinguished names being specified are valid, as it
                                 performs far fewer queries.
-        :param include_primary: If true, includes the computer's primary group in the returned groups. This adds a
-                                significant performance cost so only enable this if needed.
+        :param include_primary: If true, includes the computer's primary group as the first entry in the returned group
+                                list. This adds an additional performance cost so only enable this if needed.
         :returns: A list of ADGroup objects representing the groups that this user belongs to.
         :raises: a DuplicateNameException if a computer name is specified and more than one entry exists with the name.
         :raises: a InvalidLdapParameterException if the computer name is not a string or ADComputer.
@@ -1909,8 +1911,9 @@ class ADSession:
                                 Defaults to False. This can be used to make this function more performant when
                                 the caller knows all the distinguished names being specified are valid, as it
                                 performs far fewer queries.
-        :param include_primary: If true, includes the computers' primary groups in the returned groups. This adds a
-                                significant performance cost so only enable this if needed.
+        :param include_primary: If true, includes the computers' primary groups as the first entry in each computer's
+                                returned group list. This adds an additional performance cost so only enable this
+                                if needed.
         :returns: A dictionary mapping computers to lists of ADGroup objects representing the groups that they belong to
         :raises: a DuplicateNameException if a computer name is specified and more than one entry exists with the name.
         :raises: a InvalidLdapParameterException if any computers are not a string or ADComputer.

--- a/ms_active_directory/core/ad_session.py
+++ b/ms_active_directory/core/ad_session.py
@@ -1688,13 +1688,13 @@ class ADSession:
         entity_dns_to_entities = ldap_utils.normalize_entities_to_entity_dns(entities, lookup_by_name_fn, controls,
                                                                              skip_validation)
 
-        filter_pieces = []
+        filter_pieces = set()
         mapping_dict = {}
         primary_group_dict = {}
         for entity_dn, entity in entity_dns_to_entities.items():
             filter_piece = '({}={})'.format(ldap_constants.AD_ATTRIBUTE_MEMBER,
                                             ldap_utils.escape_dn_for_filter(entity_dn))
-            filter_pieces.append(filter_piece)
+            filter_pieces.add(filter_piece)
             mapping_dict[entity] = []
             if include_primary:
                 # get objectSid and primaryGroupID for entity
@@ -1709,7 +1709,7 @@ class ADSession:
                     # get the objectSid for the primary group given the entity's objectSid and the primaryGroupID
                     group_sid = ldap_utils.construct_primary_group_sid(entity_sid, primary_group_id)
                     primary_filter_piece = '({}={})'.format(ldap_constants.AD_ATTRIBUTE_OBJECT_SID, group_sid)
-                    filter_pieces.append(primary_filter_piece)
+                    filter_pieces.add(primary_filter_piece)
 
                     # save objectSid to dictionary for entity_dn for quick lookup later
                     primary_group_dict[entity_dn] = group_sid

--- a/ms_active_directory/core/ad_session.py
+++ b/ms_active_directory/core/ad_session.py
@@ -1946,8 +1946,8 @@ class ADSession:
             raise InvalidLdapParameterException('The account must be either a string, ADUser object, or ADComputer '
                                                 'object. {} is not of these types.'.format(account))
         if informed_account is None:
-            raise ObjectNotFoundException('No group could be found in the domain with the Group object class using '
-                                          'group {}'.format(account))
+            raise ObjectNotFoundException('No account could be found in the domain with the User or Computer object '
+                                          'class using account {}'.format(account))
 
         account_sid = informed_account.get(ldap_constants.AD_ATTRIBUTE_OBJECT_SID)
         primary_group_id = informed_account.get(ldap_constants.AD_ATTRIBUTE_PRIMARY_GROUP_ID)

--- a/ms_active_directory/environment/ldap/ldap_format_utils.py
+++ b/ms_active_directory/environment/ldap/ldap_format_utils.py
@@ -370,9 +370,12 @@ def validate_and_normalize_logon_name(name: str, supports_legacy_behavior: bool)
     return name
 
 
+# TODO: change this to read base sid from cached domain object sid
 def construct_primary_group_sid(object_sid: str, primary_group_id: int) -> str:
     """ Construct the objectSid for the primary group of an object given the objectSid of the object in question
     and the primaryGroupID for the object.
+
+    Relevant microsoft doc: https://docs.microsoft.com/en-us/windows/win32/adschema/a-primarygroupid
     """
     base_sid = object_sid[:object_sid.rfind('-')]
     return '{base}-{rid}'.format(base=base_sid, rid=primary_group_id)

--- a/ms_active_directory/environment/ldap/ldap_format_utils.py
+++ b/ms_active_directory/environment/ldap/ldap_format_utils.py
@@ -368,3 +368,11 @@ def validate_and_normalize_logon_name(name: str, supports_legacy_behavior: bool)
             raise InvalidDomainParameterException('Common names may not contain any of the following characters: '
                                                   '{}'.format(', '.join(AD_USERNAME_RESTRICTED_CHARS)))
     return name
+
+
+def construct_primary_group_sid(object_sid: str, primary_group_id: int) -> str:
+    """ Construct the objectSid for the primary group of an object given the objectSid of the object in question
+    and the primaryGroupID for the object.
+    """
+    base_sid = object_sid[:object_sid.rfind('-')]
+    return '{base}-{rid}'.format(base=base_sid, rid=primary_group_id)

--- a/ms_active_directory/environment/ldap/ldap_format_utils.py
+++ b/ms_active_directory/environment/ldap/ldap_format_utils.py
@@ -379,3 +379,10 @@ def construct_primary_group_sid(object_sid: str, primary_group_id: int) -> str:
     """
     base_sid = object_sid[:object_sid.rfind('-')]
     return '{base}-{rid}'.format(base=base_sid, rid=primary_group_id)
+
+
+def get_rid_from_object_sid(object_sid: str) -> int:
+    """ Given an objectSid, return the RID (Relative Identifier) of the object.
+    """
+    rid_string = object_sid[object_sid.rfind('-') + 1:]
+    return int(rid_string)


### PR DESCRIPTION
Any feedback would be appreciated on these additions. I also would like to add a method to find all members of a group including those that have it set as their primary group, since these are not included on the members attribute of a group.