### PR TITLE
Fix ADObject.get returning empty lists on undefined attributes

### DIFF
--- a/ms_active_directory/core/ad_objects.py
+++ b/ms_active_directory/core/ad_objects.py
@@ -141,6 +141,9 @@ class ADObject:
     def get(self, attribute_name: str, unpack_one_item_lists=False):
         """ Get an attribute about the object that isn't explicitly tracked as a member """
         val = self.all_attributes.get(attribute_name)
+        # if val is not defined, return None instead of an empty list:
+        if not val:
+            return None
         # there's a lot of 1-item lists from the ldap3 library
         if isinstance(val, list) and len(val) == 1 and unpack_one_item_lists:
             return copy.deepcopy(val[0])

--- a/ms_active_directory/core/ad_session.py
+++ b/ms_active_directory/core/ad_session.py
@@ -1722,7 +1722,7 @@ class ADSession:
             # complexity of checking all input entities for all results to O(n^2) instead of O(n^3).
             # cast all members to lowercase for a case-insensitive membership check. our normalization
             # function gave use lowercase DNs
-            member_set = set(member.lower() for member in result.get(ldap_constants.AD_ATTRIBUTE_MEMBER))
+            member_set = set(member.lower() for member in result.get(ldap_constants.AD_ATTRIBUTE_MEMBER) or [])
             group_sid = result.get(ldap_constants.AD_ATTRIBUTE_OBJECT_SID) if include_primary else None
             for entity_dn in entity_dns_to_entities:
                 if include_primary and primary_group_dict[entity_dn] == group_sid:


### PR DESCRIPTION
Essentially, if querying an attribute that does not have a value set in the domain, it will return an empty list by default. This can be annoying in some situations and I think a better behavior would be to return None in these situations.