### PR TITLE
Dev to main for 1.12.0

### DIFF
--- a/docs/source/ad_session.rst
+++ b/docs/source/ad_session.rst
@@ -126,6 +126,14 @@ There are functions for finding domain resources, such as DNS servers, CA certif
 
         :returns: A list of ADGroupPolicy objects representing the policies in the domain.
 
+    def find_sid_for_domain(self) -> str:
+        Returns the SID identifier for the domain as a string. This will be unique even if multiple different
+        domains exist with the same DNS name (e.g. a domain was cloned from one data center to another) and
+        is a part of the SIDs of domain members.
+        This will be cached after one lookup because the domain SID doesn't change.
+
+        :returns: A string representing the domain SID.
+
     find_supported_sasl_mechanisms_for_domain(self) -> List[str]
         Attempt to discover the SASL mechanisms supported by the domain and return them.
         This just builds upon the functionality that the domain has for this, as you don't need
@@ -134,6 +142,16 @@ There are functions for finding domain resources, such as DNS servers, CA certif
         This is included in the session object for completeness.
         :returns: A list of strings indicating the supported SASL mechanisms for the domain.
                   ex: ['GSSAPI', 'GSS-SPNEGO', 'EXTERNAL']
+
+    def find_upn_suffixes_for_domain(self) -> List[str]:
+        Get the user principal name suffixes for the domain. These are alternate domains that users might have
+        in their user principal name, and use for logging on.
+        For example, a domain that has a read-only domain controller exposed to the internet might support logon
+        using both "company.local" and "company.com" so that people can use their username@company.com emails to
+        login.
+        Similarly, after a merger/acquisition, this may be used to support a smooth transition if trust relationships
+        aren't used - where the domains are merged while still allowing "@company1.local" and "@company2.local"
+        emails to be used for login (since many other services may be using AD for auth).
 
     is_domain_close_in_time_to_localhost(self, allowed_drift_seconds=None) -> bool
         Get whether the domain time is close to the current local time.

--- a/docs/source/ad_session.rst
+++ b/docs/source/ad_session.rst
@@ -282,6 +282,18 @@ You can also look up attributes about the things you look up by specifying a lis
         :returns: an ADGroup object or None if the group does not exist.
         :raises: a DuplicateNameException if more than one entry exists with this name.
 
+    def find_computer_by_principal_name(self, computer_name: str, attributes_to_lookup: List[str] = None,
+                                        controls: List[Control] = None) -> Optional[ADComputer]:
+        Find a Computer in AD based on a specified userPrincipalName and return it along with any
+        requested attributes.
+        :param computer_name: The userPrincipalName name of the computer.
+        :param attributes_to_lookup: A list of additional LDAP attributes to query for the computer. Regardless of
+                                     what's specified, the computer's name and object class attributes will be queried.
+        :param controls: A list of LDAP controls to use when performing the search. These can be used to specify
+                         whether or not certain properties/attributes are critical, which influences whether a search
+                         may succeed or fail based on their availability.
+        :returns: an ADComputer object or None if the computer does not exist.
+
     find_group_by_sam_name(self, group_name: str, attributes_to_lookup: List[str] = None, controls: List[ldap3.protocol.rfc4511.Control] = None) -> Union[ms_active_directory.core.ad_objects.ADGroup, NoneType]
         Find a Group in AD based on a specified sAMAccountName name and return it along with any
         requested attributes.
@@ -424,6 +436,18 @@ You can also look up attributes about the things you look up by specifying a lis
                          may succeed or fail based on their availability.
         :returns: an ADUser object or None if the user does not exist.
         :raises: a DuplicateNameException if more than one entry exists with this name.
+
+    def find_user_by_principal_name(self, user_name: str, attributes_to_lookup: List[str] = None,
+                                    controls: List[Control] = None) -> Optional[ADUser]:
+        Find a User in AD based on a specified userPrincipalName and return it along with any
+        requested attributes.
+        :param user_name: The userPrincipalName name of the user.
+        :param attributes_to_lookup: A list of additional LDAP attributes to query for the user. Regardless of
+                                     what's specified, the user's name and object class attributes will be queried.
+        :param controls: A list of LDAP controls to use when performing the search. These can be used to specify
+                         whether or not certain properties/attributes are critical, which influences whether a search
+                         may succeed or fail based on their availability.
+        :returns: an ADUser object or None if the user does not exist.
 
     find_user_by_sam_name(self, user_name: str, attributes_to_lookup: List[str] = None, controls: List[ldap3.protocol.rfc4511.Control] = None) -> Union[ms_active_directory.core.ad_objects.ADUser, NoneType]
         Find a User in AD based on a specified sAMAccountName name and return it along with any

--- a/ms_active_directory/core/ad_objects.py
+++ b/ms_active_directory/core/ad_objects.py
@@ -141,6 +141,9 @@ class ADObject:
     def get(self, attribute_name: str, unpack_one_item_lists=False):
         """ Get an attribute about the object that isn't explicitly tracked as a member """
         val = self.all_attributes.get(attribute_name)
+        # if val is not defined, return None instead of an empty list:
+        if not val:
+            return None
         # there's a lot of 1-item lists from the ldap3 library
         if isinstance(val, list) and len(val) == 1 and unpack_one_item_lists:
             return copy.deepcopy(val[0])

--- a/ms_active_directory/core/ad_session.py
+++ b/ms_active_directory/core/ad_session.py
@@ -1756,7 +1756,7 @@ class ADSession:
             # complexity of checking all input entities for all results to O(n^2) instead of O(n^3).
             # cast all members to lowercase for a case-insensitive membership check. our normalization
             # function gave use lowercase DNs
-            member_set = set(member.lower() for member in result.get(ldap_constants.AD_ATTRIBUTE_MEMBER))
+            member_set = set(member.lower() for member in result.get(ldap_constants.AD_ATTRIBUTE_MEMBER) or [])
             group_sid = result.get(ldap_constants.AD_ATTRIBUTE_OBJECT_SID) if include_primary else None
             for entity_dn in entity_dns_to_entities:
                 if include_primary and primary_group_dict[entity_dn] == group_sid:

--- a/ms_active_directory/environment/ldap/ldap_constants.py
+++ b/ms_active_directory/environment/ldap/ldap_constants.py
@@ -98,6 +98,7 @@ AD_ATTRIBUTE_ADDITIONAL_DNS_HOST_NAME = 'msDS-AdditionalDnsHostName'
 AD_ATTRIBUTE_CA_CERT = 'caCertificate'
 
 # keys for domains and trusted domains
+AD_ADDITIONAL_UPN_SUFFIXES = 'uPNSuffixes'
 AD_DOMAIN_DNS_ROOT = 'dnsRoot'
 AD_DOMAIN_FUNCTIONAL_LEVEL = 'domainFunctionality'
 AD_DOMAIN_SUPPORTED_SASL_MECHANISMS = 'supportedSASLMechanisms'

--- a/ms_active_directory/environment/ldap/ldap_format_utils.py
+++ b/ms_active_directory/environment/ldap/ldap_format_utils.py
@@ -370,15 +370,13 @@ def validate_and_normalize_logon_name(name: str, supports_legacy_behavior: bool)
     return name
 
 
-# TODO: change this to read base sid from cached domain object sid
-def construct_primary_group_sid(object_sid: str, primary_group_id: int) -> str:
-    """ Construct the objectSid for the primary group of an object given the objectSid of the object in question
-    and the primaryGroupID for the object.
+def construct_primary_group_sid(domain_sid: str, primary_group_id: int) -> str:
+    """ Construct the objectSid for the primary group of an object given the domain SID
+    and the primaryGroupID for an object.
 
     Relevant microsoft doc: https://docs.microsoft.com/en-us/windows/win32/adschema/a-primarygroupid
     """
-    base_sid = object_sid[:object_sid.rfind('-')]
-    return '{base}-{rid}'.format(base=base_sid, rid=primary_group_id)
+    return '{base}-{rid}'.format(base=domain_sid, rid=primary_group_id)
 
 
 def get_rid_from_object_sid(object_sid: str) -> int:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-version = '1.11.2'
+version = '1.12.0'
 author = 'Azaria Zornberg'
 email = 'a.zornberg96@gmail.com'
 license_str = 'MIT License'


### PR DESCRIPTION
The primary component of this release is user principal name functionality. New features include:

1. Finding the user principal name suffixes for a domain, which can be helpful for searching or determining how to logon in cases where only a short username is known
2. Finding users and computers by principal name
3. Support for using user and computer principals in other functions, like group membership lookups, account disable/enable, password changes, etc.

Other small enhancements include:

1. Functionality to lookup the SID for a domain
2. Checking if a session is anonymous
3. `ADObject` now returns `None` for attributes that are not present in the response
4. The permissions a session needs to find primary group memberships has decreased, and the bandwidth used has also decreased, as the domain SID is now used in such lookups rather than querying the `objectSID` for all users every time.