### PR TITLE
Default to an empty list for object classes

### DIFF
--- a/ms_active_directory/core/ad_objects.py
+++ b/ms_active_directory/core/ad_objects.py
@@ -112,7 +112,7 @@ class ADObject:
         self.distinguished_name = dn
         self.domain = domain
         self.all_attributes = attributes if attributes else {}
-        self.object_classes = attributes.get(AD_ATTRIBUTE_OBJECT_CLASS)
+        self.object_classes = attributes.get(AD_ATTRIBUTE_OBJECT_CLASS, [])
         # used for __repr__
         self.class_name = 'ADObject'
 


### PR DESCRIPTION
Defaults to an empty list for object classes so that ADobjects are always hashable.

Fixes a bug in find_members_of_group_recursive() caused by [placeholder ADobjects](
https://github.com/zorn96/ms_active_directory/blob/0c9686423ec087fa6ad27d1301bc3c4eca006ba3/ms_active_directory/core/ad_session.py#L2349) when hitting [this line](https://github.com/zorn96/ms_active_directory/blob/0c9686423ec087fa6ad27d1301bc3c4eca006ba3/ms_active_directory/core/ad_session.py#L2284)