### PR TITLE
Cannot get attributes with value '0'

### DIFF
--- a/ms_active_directory/core/ad_objects.py
+++ b/ms_active_directory/core/ad_objects.py
@@ -142,7 +142,7 @@ class ADObject:
         """ Get an attribute about the object that isn't explicitly tracked as a member """
         val = self.all_attributes.get(attribute_name)
         # if val is not defined, return None instead of an empty list:
-        if not val:
+        if val == []:
             return None
         # there's a lot of 1-item lists from the ldap3 library
         if isinstance(val, list) and len(val) == 1 and unpack_one_item_lists:


### PR DESCRIPTION
Only return `None` if it actually is an empty list (as per the comment above). Currently, attributes correctly set to `0` cannot be returned.