### PR TITLE
Strict option for group membership

### DIFF
--- a/ms_active_directory/core/ad_session.py
+++ b/ms_active_directory/core/ad_session.py
@@ -2427,7 +2427,8 @@ class ADSession:
                                              groups_to_modify: List[Union[str, ADGroup]],
                                              member_lookup_fn: callable, stop_and_rollback_on_error: bool,
                                              adding: bool, controls: List[Control],
-                                             skip_validation: bool) -> List[Union[str, ADGroup]]:
+                                             skip_validation: bool,
+                                             strict: bool = False) -> List[Union[str, ADGroup]]:
         """ Either add or remove members to/from groups. Members may be users or groups or string distinguished names.
         If there are any failures adding/removing for a group, and stop_and_rollback_on_error is True, we will attempt
         to undo the changes that have been done. If rollback fails, we will raise an exception. If it succeeds, we still
@@ -2467,8 +2468,9 @@ class ADSession:
         for group_dn in target_group_list:
             logger.info('Attempting to %s the following members to/from group %s : %s', verb, member_dn_list,
                         group_dn)
-            # by setting fix to True, we ignore members already in the group and make this idempotent
-            res = member_modify_fn(member_dn_list, [group_dn], fix=True)
+            # when fix is True, we ignore members already in the group and make this idempotent, otherwise this should
+            # only be called on non-members (strict)
+            res = member_modify_fn(member_dn_list, [group_dn], fix=not strict)
             # the function returns a boolean on whether it succeeded or not
             if not res:
                 failing_group = group_dn

--- a/ms_active_directory/core/ad_session.py
+++ b/ms_active_directory/core/ad_session.py
@@ -2535,9 +2535,9 @@ class ADSession:
                                 Defaults to False. This can be used to make this function more performant when
                                 the caller knows all the distinguished names being specified are valid, as it
                                 performs far fewer queries.
-        :param strict: If true, assume that all distinguished names are not already group members and that the target
-                       groups already exist. This removes idempotency. Increases performance significantly when working
-                       with large groups.
+        :param strict: If true, assume that all distinguished names are not already group members in any of the target
+                       groups and that the target groups exist. This removes idempotency. Increases performance
+                       significantly when working with large groups.
         :returns: A list of groups that successfully had members added. This will always be all the groups unless
                   stop_and_rollback_on_error is False.
         :raises: MembershipModificationException if any groups being added also exist in the groups to add them to, or
@@ -2571,9 +2571,9 @@ class ADSession:
                                 Defaults to False. This can be used to make this function more performant when
                                 the caller knows all the distinguished names being specified are valid, as it
                                 performs far fewer queries.
-        :param strict: If true, assume that all distinguished names are not already group members and that the target
-                       groups already exist. This removes idempotency. Increases performance significantly when working
-                       with large groups.
+        :param strict: If true, assume that all distinguished names are not already group members in any of the target
+                       groups and that the target groups exist. This removes idempotency. Increases performance
+                       significantly when working with large groups.
         :returns: A list of groups that successfully had members added. This will always be all the groups unless
                   stop_and_rollback_on_error is False.
         :raises: MembershipModificationException if we fail to add users to any groups and rollback succeeds.
@@ -2606,9 +2606,9 @@ class ADSession:
                                 Defaults to False. This can be used to make this function more performant when
                                 the caller knows all the distinguished names being specified are valid, as it
                                 performs far fewer queries.
-        :param strict: If true, assume that all distinguished names are not already group members and that the target
-                       groups already exist. This removes idempotency. Increases performance significantly when working
-                       with large groups.
+        :param strict: If true, assume that all distinguished names are not already group members in any of the target
+                       groups and that the target groups exist. This removes idempotency. Increases performance
+                       significantly when working with large groups.
         :returns: A list of groups that successfully had members added. This will always be all the groups unless
                   stop_and_rollback_on_error is False.
         :raises: MembershipModificationException if we fail to add computers to any groups and rollback succeeds.
@@ -2642,9 +2642,9 @@ class ADSession:
                                 Defaults to False. This can be used to make this function more performant when
                                 the caller knows all the distinguished names being specified are valid, as it
                                 performs far fewer queries.
-        :param strict: If true, assume that all distinguished names are currently group members and that the target
-                       groups already exist. This removes idempotency. Increases performance significantly when working
-                       with large groups.
+        :param strict: If true, assume that all distinguished names are currently group members in all target groups
+                       and that the target groups exist. This removes idempotency. Increases performance significantly
+                       when working with large groups.
         :returns: A list of groups that successfully had members removed. This will always be all the groups unless
                   stop_and_rollback_on_error is False.
         :raises: MembershipModificationException if we fail to remove groups from any other groups and rollback succeeds
@@ -2678,9 +2678,9 @@ class ADSession:
                                 Defaults to False. This can be used to make this function more performant when
                                 the caller knows all the distinguished names being specified are valid, as it
                                 performs far fewer queries.
-        :param strict: If true, assume that all distinguished names are currently group members and that the target
-                       groups already exist. This removes idempotency. Increases performance significantly when working
-                       with large groups.
+        :param strict: If true, assume that all distinguished names are currently group members in all target groups
+                       and that the target groups exist. This removes idempotency. Increases performance significantly
+                       when working with large groups.
         :returns: A list of groups that successfully had members removed. This will always be all the groups unless
                   stop_and_rollback_on_error is False.
         :raises: MembershipModificationException if we fail to remove users from any groups and rollback succeeds
@@ -2715,9 +2715,9 @@ class ADSession:
                                 Defaults to False. This can be used to make this function more performant when
                                 the caller knows all the distinguished names being specified are valid, as it
                                 performs far fewer queries.
-        :param strict: If true, assume that all distinguished names are currently group members and that the target
-                       groups already exist. This removes idempotency. Increases performance significantly when working
-                       with large groups.
+        :param strict: If true, assume that all distinguished names are currently group members in all target groups
+                       and that the target groups exist. This removes idempotency. Increases performance significantly
+                       when working with large groups.
         :returns: A list of groups that successfully had members removed. This will always be all the groups unless
                   stop_and_rollback_on_error is False.
         :raises: MembershipModificationException if we fail to remove computers from any groups and rollback succeeds


### PR DESCRIPTION
This PR aims to add a 'strict' option to group add/removing functions. It removes the idempotency (if requested strict mode) in return for a huge performance boost when working with very large groups.

In our use case, we have huge groups, probably slow AD servers and we KNOW the users are not currently in the groups we plan to add them to. It makes the difference of 55 seconds per operation to less than 1 second.

By the time I remove the "WIP" flag I intend this code to not contain syntax errors (apologies from before).

If you don't like the naming or documentation wording of "strict" please let me know @zorn96 . I was going to piggyback from `skip_validation` but thought this might not be welcomed.

https://github.com/zorn96/ms_active_directory/issues/92

Many thanks

(I'm probably going to kindly ask for a minor release as well if this gets accepted as it will make a huge difference for us)